### PR TITLE
Update GIMBAL_LOCK_AVOIDANCE.agc

### DIFF
--- a/Luminary069/GIMBAL_LOCK_AVOIDANCE.agc
+++ b/Luminary069/GIMBAL_LOCK_AVOIDANCE.agc
@@ -16,10 +16,9 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2016-12-13 MAS  Created from Luminary 99.
 ##              2016-12-14 MAS  Updated from comment-proofed Luminary 99 version.
+##		2017-01-13 RRB	Updated for Luminary 69.
 
-## NOTE: Page numbers below have not yet been updated to reflect Luminary 69.
-
-## Page 364
+## Page 377
 		BANK	15
 		
 		SETLOC	KALCMON1


### PR DESCRIPTION
Update page number for Luminary 69. Nothing else changed between version.