### PR TITLE
Update IMU_MODE_SWITCHING_ROUTINES.agc

### DIFF
--- a/Luminary099/IMU_MODE_SWITCHING_ROUTINES.agc
+++ b/Luminary099/IMU_MODE_SWITCHING_ROUTINES.agc
@@ -16,6 +16,7 @@
 ##		2016-12-13 RSB	GOTOP00H -> GOTOPOOH
 ##		2016-12-18 RSB	Proofed text comments with octopus/ProoferComments
 ##				and corrected the errors found.
+##		2017-01-18 RRB	Found typo while updating for Luminary 69.
 
 ## This source code has been transcribed or otherwise adapted from
 ## digitized images of a hardcopy from the MIT Museum.  The digitization
@@ -852,7 +853,7 @@ GOMANUR		CA	ATTCADR		# IS KALCMANU FREE
 		EXTEND
 		BZF	+3
 		
-		TC	P00DOO		# NO
+		TC	POODOO		# NO
 		OCT	1210		# 2 TRYING TO USE SAME DEVICE
 		
  +3		EXTEND


### PR DESCRIPTION
Found a typo when updating Luminary 69.