### PR TITLE
Improved handling of Z and ZRUPT

### DIFF
--- a/Borealis/ERASABLE_ASSIGNMENTS.agc
+++ b/Borealis/ERASABLE_ASSIGNMENTS.agc
@@ -14,6 +14,7 @@
 ##              2016-12-21 MAS  Pulled in erasables for Retread instruction checks.
 ##              2017-01-04 MAS  Added ERESTORE, used by Sunburst's erasable mem check.
 ##              2017-01-15 MAS  Added T4TEMP and LASTIMER for use with timer/EDRUPT tests.
+##              2017-09-03 MAS  Pulled in RSBBQ from Luminary, since it is quite useful.
 
 A               EQUALS          0
 L               EQUALS          1                               # L AND Q ARE BOTH CHANNELS AND REGISTERS.
@@ -474,6 +475,10 @@ NDXSELF2	ERASE
 
 LST1            ERASE           +7                              # DELTA T'S.
 LST2            ERASE           +17D                            # 2CADR TASK ADDRESSES.
+
+#          RESTART STORAGE.                              (2D)
+
+RSBBQ           ERASE           +1                      # B(2)PRM SAVE BB AND Q FOR RESTARTS.
 
 # IMU COMPENSATION PARAMETERS:
 

--- a/Borealis/FRESH_START_AND_RESTART.agc
+++ b/Borealis/FRESH_START_AND_RESTART.agc
@@ -15,6 +15,7 @@
 ##              2017-01-04 MAS  Added init/checking of ERESTORE for the updated
 ##                              erasable check from Sunburst.
 ##              2017-01-27 MAS  Added an instruction I missed pulling from Sunburst.
+##              2017-09-03 MAS  Pulled in RSBBQ from Luminary, since it is quite useful.
 
                 BANK            12 
                 EBANK=          LST1
@@ -91,6 +92,11 @@ STARTSIM        CAF             BIT14
 #          COMES HERE FROM LOCATION 4000, GOJAM. RESTART ANY PROGRAMS WHICH MAY HAVE BEEN RUNNING AT THE TIME.
 
 GOPROG          INCR            REDOCTR                 # ADVANCE RESTART COUNTER.
+
+                LXCH            Q
+                EXTEND
+                ROR             SUPERBNK
+                DXCH            RSBBQ
 
                 TC              STARTSUB                # COMMON INITIALIZATION ROUTINE.
                 


### PR DESCRIPTION
This implements the quirks of Z/ZRUPT as described in #1048, and includes new tests in Borealis to exercise them. yaAGC seems happy, but I'd like to run the new Borealis on hardware before merging this in, to make sure everything works as I expect.