### PR TITLE
yaAGC: Added simulation of "total nonsense" in DV and other unexpected cases

### DIFF
--- a/Borealis/AGC_BLOCK_TWO_EXTENDED_TESTS.agc
+++ b/Borealis/AGC_BLOCK_TWO_EXTENDED_TESTS.agc
@@ -24,6 +24,11 @@
 ##                              and division by A and L. The L cases are not yet written,
 ##                              and I intend to add a separate case for DV Z when I figure
 ##                              out the best way to do it.
+##              2017-09-18 MAS  Filled out DV L entries in the division table. The only
+##                              remaining cases I want to cover are DV Z, which need some
+##                              tweaks to divisor determination, and will require moving
+##                              the division to a fixed location (probably the start of
+##                              this bank).
 
                 BANK            24
 # The extended tests check out functionalities not exercised by the Aurora or Retread tests. First up
@@ -394,7 +399,7 @@ DVTBL           2OCT            1010414241                      # Dividend
                 2OCT            3545321212                      # Dividend
                 OCT             00000                           # Divisor = A
                 OCT             77777                           # Quotient
-                OCT             61212                           # Remainder
+                OCT             21212                           # Remainder (actually 061212 but L is overflow corrected)
                 OCT             1                               # A +overflow
 
 # Nonsense division with - overflow A as divisor
@@ -402,7 +407,63 @@ DVTBL           2OCT            1010414241                      # Dividend
                 OCT             00000                           # Divisor = A
                 OCT             01010                           # Quotient
                 OCT             61151                           # Remainder (actually 121151 but L is overflow corrected)
-DVTBLEND        OCT             1                               # A -overflow
+                OCT             1                               # A -overflow
+
+# Regular division with positive dividend and positive L as divisor (L gets + overflow)
+                2OCT            1743131231                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             23526                           # Quotient
+                OCT             22063                           # Remainder
+                OCT             0                               # No overflow
+
+# Regular division with positive dividend and negative L as divisor (L = L + 40000)
+                2OCT            2540047102                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             30531                           # Quotient
+                OCT             02770                           # Remainder
+                OCT             0                               # No overflow
+
+# Regular division with negative dividend and positive L as divisor (L = -L + 40000)
+                2OCT            7651711246                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             76065                           # Quotient
+                OCT             64651                           # Remainder
+                OCT             0                               # No overflow
+
+# Regular division with negative dividend and negative L as divisor (L = -L with + overflow)
+                2OCT            5077544044                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             45507                           # Quotient
+                OCT             64614                           # Remainder
+                OCT             0                               # No overflow
+
+# Nonsense division with positive dividend and positive L as divisor (L gets + overflow)
+                2OCT            3133204417                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             37212                           # Quotient
+                OCT             02371                           # Remainder
+                OCT             0                               # No overflow
+
+# Nonsense division with positive dividend and negative L as divisor (L = L + 40000)
+                2OCT            2467267371                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             34330                           # Quotient
+                OCT             16012                           # Remainder
+                OCT             0                               # No overflow
+
+# Nonsense division with negative dividend and positive L as divisor (L = -L + 40000)
+                2OCT            5510506670                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             47773                           # Quotient
+                OCT             53327                           # Remainder
+                OCT             0                               # No overflow
+
+# Nonsense division with negative dividend and negative L as divisor (L = -L with + overflow)
+                2OCT            4222461674                      # Dividend
+                OCT             77777                           # Divisor = L
+                OCT             40750                           # Quotient
+                OCT             63701                           # Remainder
+DVTBLEND        OCT             0                               # No overflow
 
 # Interrupt routine used in BRUPTCHK.
 ARUPTVEC        DXCH            ARUPT                           # Although Q is also destroyed, we happen to know

--- a/Borealis/Main.annotation
+++ b/Borealis/Main.annotation
@@ -6,7 +6,7 @@
 </td>
 <td style="vertical-align: middle;">
 <pre>
-   YAYUL: ASSEMBLE REVISION 6 OF PROGRAM BOREALIS       BY MSTEWART JUN. 28,2017
+   YAYUL: ASSEMBLE REVISION 7 OF PROGRAM BOREALIS       BY MSTEWART SEP. 20,2017
 </pre>
 This is a <i>modern</i> AGC system self-test program, though based on the Apollo-era AURORA 12
 program, and was not written by the original AGC developers, but rather by Mike Stewart. 

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -1742,7 +1742,7 @@ SimulateDV(agc_t *State, uint16_t divisor)
 
     // Add 40000 to L
     l = AddSP16(l, 040000);
-    // If this caused did not cause positive overflow, add one to A
+    // If this did not cause positive overflow, add one to A
     if (ValueOverflowed(l) != AGC_P1)
       a = AddSP16(a, 1);
     // Initialize the remainder with the current value of A


### PR DESCRIPTION
This implements a streamlined version of the code presented in #1047, plus implementation of the various other weirdnesses associated with DV discussed there.
* All cases where the divisor is smaller than the dividend (which result in "total nonsense") should now match results gotten on the original hardware.
* DV A, DV L, and DV Q all have special handling now to match "unexpected" modifications that happen to those registers before the divisor is sampled. All such cases I've tried match the hardware sim.
* Divisors with positive or negative overflow are also now handled by the new DV register simulation, since the overflow totally changes the results. Again, all the cases I have tried with overflow match the hardware sim.

All of the existing Aurora and Retread tests still pass, so I think at this point (unless there is some particularly weird case I haven't thought of) yaAGC should always get identical results to the hardware sim for all dividends, divisors, and registers.

I haven't yet written Borealis tests for this, but my intention is to add a whole bunch of cases for all permutations of sign, register, overflow, and nonsense-ness. I'll add those to this pull request when I'm done writing them.