### PR TITLE
Channel 163 bit for TEMP

### DIFF
--- a/piPeripheral/piDSKY.py
+++ b/piPeripheral/piDSKY.py
@@ -11,6 +11,8 @@
 #				of piDSKY2.py (in which all hardware-specific stuff
 #				has been removed), because it was easier than 
 #				back-porting bug-fixes.
+#		2018-01-06 MAS	Switched the TEMP light to use channel 163 instead
+#				of channel 11.
 #
 # Note that certain functionality (I think the code for get_char_keyboard_nonblock)
 # might not work under Windows, but everything should
@@ -428,14 +430,8 @@ def outputFromAGC(channel, value):
 				updateLampStatuses("UPLINK ACTY", True)
 			else:
 				updateLampStatuses("UPLINK ACTY", False)
-			temp = "TEMP OFF        "
-			if (value & 0x08) != 0:
-				temp = "TEMP ON         "
-				updateLampStatuses("TEMP", True)
-			else:
-				updateLampStatuses("TEMP", False)
 			flashing = "V/N NO FLASH    "
-			print(compActy + "   " + uplinkActy + "   " + temp + "   " + "   " + flashing)
+			print(compActy + "   " + uplinkActy + "   " + "   " + flashing)
 			updateLamps()
 		elif channel == 0o13:
 			last13 = value
@@ -446,6 +442,12 @@ def outputFromAGC(channel, value):
 			updateLamps()
 		elif channel == 0o163:
 			last163 = value
+			if (value & 0x08) != 0:
+				temp = "TEMP ON         "
+				updateLampStatuses("TEMP", True)
+			else:
+				temp = "TEMP OFF        "
+				updateLampStatuses("TEMP", False)
 			if (value & 0o400) != 0:
 				standby = "DSKY STANDBY ON "
 				updateLampStatuses("DSKY STANDBY", True)
@@ -470,7 +472,7 @@ def outputFromAGC(channel, value):
 			else:
 				restart = "RESTART OFF     "
 				updateLampStatuses("RESTART", False)
-			print(standby + "   " + keyRel + "   " + oprErr + "   " + restart)
+			print(temp + "   " + standby + "   " + keyRel + "   " + oprErr + "   " + restart)
 		else:
 			print("Received from yaAGC: " + oct(value) + " -> channel " + oct(channel))
 	return

--- a/piPeripheral/piDSKY2.py
+++ b/piPeripheral/piDSKY2.py
@@ -131,6 +131,8 @@
 #				where the command is executed in the background
 #				by shelling out.  Thus, arbitrary BASH commands such
 #				as audio playback can be put into the script.
+#		2018-01-06 MAS	Switched the TEMP light to use channel 163 instead
+#				of channel 11.
 #
 # About the design of this program ... yes, a real Python developer would 
 # objectify it and have lots and lots of individual modules defining the objects.
@@ -1229,12 +1231,6 @@ def outputFromAGC(channel, value):
 			updateLampStatuses("UPLINK ACTY", True)
 		else:
 			updateLampStatuses("UPLINK ACTY", False)
-		temp = "TEMP OFF        "
-		if (value & 0x08) != 0:
-			temp = "TEMP ON         "
-			updateLampStatuses("TEMP", True)
-		else:
-			updateLampStatuses("TEMP", False)
 		flashing = "V/N NO FLASH    "
 		if (value & 0x20) != 0:
 			if not vnFlashing:
@@ -1246,7 +1242,7 @@ def outputFromAGC(channel, value):
 		else:
 			if vnFlashing != False:
 				vnFlashingStop()
-		print(compActy + "   " + uplinkActy + "   " + temp + "   " + "   " + flashing)
+		print(compActy + "   " + uplinkActy + "   " + "   " + "   " + flashing)
 		updateLamps()
 	elif channel == 0o13:
 		test = "DSKY TEST       "
@@ -1255,6 +1251,12 @@ def outputFromAGC(channel, value):
 		print(test)
 		updateLamps()
 	elif channel == 0o163:
+		if (value & 0x08) != 0:
+			temp = "TEMP ON         "
+			updateLampStatuses("TEMP", True)
+		else:
+			temp = "TEMP OFF        "
+			updateLampStatuses("TEMP", False)
 		if (value & 0o400) != 0:
 			standby = "DSKY STANDBY ON "
 			updateLampStatuses("DSKY STANDBY", True)
@@ -1279,7 +1281,7 @@ def outputFromAGC(channel, value):
 		else:
 			restart = "RESTART OFF     "
 			updateLampStatuses("RESTART", False)
-		print(standby + "   " + keyRel + "   " + oprErr + "   " + restart)
+		print(temp + "   " + standby + "   " + keyRel + "   " + oprErr + "   " + restart)
 		updateLamps()
 	else:
 		print("Received from yaAGC: " + oct(value) + " -> channel " + oct(channel))

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -369,6 +369,10 @@
  *				state via an ever-present GOJAM during standby,
  *				but the standby enabled bit (CH13 bit 11) is not
  *				required to be set to exit standby, only to enter.
+ *		01/06/18 MAS	Added a new channel 163 bit for the TEMP light,
+ *				which is the logical OR of channel 11 bit 4 and
+ *				channel 30 bit 15. The AGC did this internally
+ *				so the light would still work in standby.
  *
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -1658,7 +1658,7 @@ UpdateDSKY(agc_t *State)
 {
   unsigned LastChannel163 = State->DskyChannel163;
 
-  State->DskyChannel163 &= ~(DSKY_KEY_REL | DSKY_VN_FLASH | DSKY_OPER_ERR | DSKY_RESTART | DSKY_STBY | DSKY_AGC_WARN);
+  State->DskyChannel163 &= ~(DSKY_KEY_REL | DSKY_VN_FLASH | DSKY_OPER_ERR | DSKY_RESTART | DSKY_STBY | DSKY_AGC_WARN | DSKY_TEMP);
 
   if (State->InputChannel[013] & 01000)
     // The light test is active. Light RESTART and STBY.
@@ -1671,6 +1671,10 @@ UpdateDSKY(agc_t *State)
   // Make the RESTART light mirror State->RestartLight.
   if (State->RestartLight)
     State->DskyChannel163 |= DSKY_RESTART;
+
+  // Light TEMP if channel 11 bit 4 is set, or channel 30 bit 15 is set
+  if ((State->InputChannel[011] & 010) || (State->InputChannel[030] & 040000))
+    State->DskyChannel163 |= DSKY_TEMP;
 
   // Set KEY REL and OPER ERR according to channel 11
   if (State->InputChannel[011] & DSKY_KEY_REL)

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -113,7 +113,11 @@
 				the AGC (CMC/LGC) warning light.
 		05/30/17 RSB	Added initializeSunburst37.
 		07/13/17 MAS	Added flags for the three HANDRUPT traps.
-   
+		01/06/18 MAS	Added a new channel 163 bit for the TEMP light,
+				which is the logical OR of channel 11 bit 4 and
+				channel 30 bit 15. The AGC did this internally
+				so the light would still work in standby.
+ 
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
   http://hrst.mit.edu/hrs/apollo/public/archive/1704.pdf.

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -260,6 +260,7 @@ extern long random (void);
 #define CH77_NIGHT_WATCHMAN 000020
 
 #define DSKY_AGC_WARN 000001
+#define DSKY_TEMP     000010
 #define DSKY_KEY_REL  000020
 #define DSKY_VN_FLASH 000040
 #define DSKY_OPER_ERR 000100

--- a/yaDSKY/src/CM.ini
+++ b/yaDSKY/src/CM.ini
@@ -14,6 +14,8 @@
 #		06/27/05 RSB.	Added CMSIM.
 #		01/15/17 MAS.	Updated to use new channel 163
 #				mappings.
+#		01/06/18 MAS.	Made TEMP use channel 163 instead
+#				of channel 11.
 
 # The idea of the configuration file is to allow us to
 # configure yaDSKY for the DSKYs used in different Apollo
@@ -108,7 +110,7 @@ CHAN 14 163  5 0		# KEY REL
 CHAN 15 163  7 0		# OPR ERR
 CHAN 16 377  1 0		# (not used in Colossus)
 CHAN 17 377  1 0		# (not used in Colossus)
-CHAN 21  11  4 0		# TEMP
+CHAN 21 163  4 0		# TEMP
 CHAN 22  10  6 0 74000 60000	# GIMBAL LOCK
 CHAN 23  10  9 0 74000 60000	# PROG
 CHAN 24 163  8 0                # RESTART

--- a/yaDSKY/src/LM.ini
+++ b/yaDSKY/src/LM.ini
@@ -19,6 +19,8 @@
 #		06/27/05 RSB	Added LMSIM.
 #		01/15/17 MAS	Updated to use new channel 163
 #				mappings.
+#		01/06/18 MAS	Made TEMP use channel 163 instead
+#				of channel 11.
 
 # The idea of the configuration file is to allow us to
 # configure yaDSKY for the DSKYs used in different Apollo
@@ -113,7 +115,7 @@ CHAN 14 163  5 0		# KEY REL
 CHAN 15 163  7 0		# OPR ERR
 CHAN 16  10  1 0 74000 60000	# PRIO DISP (not used by Luminary 131 and earlier)
 CHAN 17  10  2 0 74000 60000	# NO DAP (not used by Luminary 131 and earlier)
-CHAN 21  11  4 0		# TEMP
+CHAN 21 163  4 0		# TEMP
 CHAN 22  10  6 0 74000 60000	# GIMBAL LOCK
 CHAN 23  10  9 0 74000 60000	# PROG
 CHAN 24 163  8 0		# RESTART

--- a/yaDSKY/src/LM0.ini
+++ b/yaDSKY/src/LM0.ini
@@ -21,6 +21,8 @@
 #				slightly more accurate picture, since
 #				Retread is the only program we have that
 #				uses this light setup.
+#		01/06/18 MAS.	Made TEMP use channel 163 instead
+#				of channel 11.
 
 # The idea of the configuration file is to allow us to
 # configure yaDSKY for the DSKYs used in different Apollo
@@ -115,7 +117,7 @@ CHAN 14  10  3 0 74000 60000    # FREE
 CHAN 15  10  4 0 74000 60000	# NO ATT
 CHAN 16 163  9 0		# STBY
 CHAN 17 163  5 0		# KEY REL
-CHAN 21  11  4 0		# TEMP
+CHAN 21 163  4 0		# TEMP
 CHAN 22  10  6 0 74000 60000	# GIMBAL LOCK
 CHAN 23  10  9 0 74000 60000	# PROG
 CHAN 24 163  8 0                # RESTART

--- a/yaDSKY/src/LM1.ini
+++ b/yaDSKY/src/LM1.ini
@@ -8,6 +8,8 @@
 #		06/27/05 RSB.	Added LMSIM
 #		01/15/17 MAS.	Updated to use new channel 163
 #		             	mappings.
+#		01/06/18 MAS.	Made TEMP use channel 163 instead
+#				of channel 11.
 
 # The idea of the configuration file is to allow us to
 # configure yaDSKY for the DSKYs used in different Apollo
@@ -102,7 +104,7 @@ CHAN 14 163  5 0		# KEY REL
 CHAN 15 163  7 0		# OPR ERR
 CHAN 16  10  1 0 74000 60000	# PRIO DISP
 CHAN 17  10  2 0 74000 60000	# NO DAP
-CHAN 21  11  4 0		# TEMP
+CHAN 21 163  4 0		# TEMP
 CHAN 22  10  6 0 74000 60000	# GIMBAL LOCK
 CHAN 23  10  9 0 74000 60000	# PROG
 CHAN 24 163  8 0		# RESTART


### PR DESCRIPTION
In the AGC, the output to the TEMP light is a logical OR of channel 11 bit 4 (the output bit to turn on the light) and channel 30 bit 15 (the input bit from the IMU indicating its temperature is out of range). This was done so the light would still work in standby mode. This is apparently needed for the TEMP light to operate correctly in NASSP, since software appears to be lazy about maintaining the output bit.

These changes add a new bit to channel 163 that indicates what the current state of the TEMP light should be, and update all of our various DSKYs to use that instead of channel 11 bit 4.

@indy91, let me know if these changes make the TEMP light work correctly for you.
  