### PR TITLE
Improved scaler logic and counter simulation for yaAGC

### DIFF
--- a/yaAGC/SocketAPI.c
+++ b/yaAGC/SocketAPI.c
@@ -77,6 +77,8 @@
 				same size as data packets.  Otherwise, it makes
 				low-level debugging of the streaming data hard,
 				because the packet alignment changes over time.
+		01/30/18 MAS	Removed old RHC input handling, to be replaced
+				with new logic later.
 */
 
 #include <errno.h>
@@ -115,13 +117,6 @@ ChannelOutput (agc_t * State, int Channel, int Value)
     {
       State->InputChannel[7] = State->OutputChannel7 = (Value & 0160);
       return;
-    }
-  // Stick data into the RHCCTR registers, if bits 8,9 of channel 013 are set.
-  if (Channel == 013 && 0600 == (0600 & Value) && !CmOrLm)
-    {
-      State->Erasable[0][042] = LastRhcPitch;
-      State->Erasable[0][043] = LastRhcYaw;
-      State->Erasable[0][044] = LastRhcRoll;
     }
   // Most output channels are simply transmitted to clients representing
   // hardware simulations.
@@ -297,26 +292,6 @@ ChannelInput (agc_t *State)
 			  {
 			    State->Erasable[0][RegINLINK] = (Value & 077777);
 			    State->InterruptRequests[7] = 1;
-			  }
-			// Fictitious registers for rotational hand controller (RHC).
-			// Note that the RHC angles are not immediately used, but
-			// merely squirreled away for later.  They won't actually
-			// go into the counter registers until the RHC counters are
-			// enabled and the data requested (bits 8,9 of channel 13).
-			else if (Channel == 0166)
-			  {
-			    LastRhcPitch = Value;
-			    ChannelOutput (State, Channel, Value);	// echo
-			  }
-			else if (Channel == 0167)
-			  {
-			    LastRhcYaw = Value;
-			    ChannelOutput (State, Channel, Value);	// echo
-			  }
-			else if (Channel == 0170)
-			  {
-			    LastRhcRoll = Value;
-			    ChannelOutput (State, Channel, Value);	// echo
 			  }
 			//---------------------------------------------------------------
 			// For --debug-dsky mode.

--- a/yaAGC/SocketAPI.c
+++ b/yaAGC/SocketAPI.c
@@ -79,6 +79,9 @@
 				because the packet alignment changes over time.
 		01/30/18 MAS	Removed old RHC input handling, to be replaced
 				with new logic later.
+		02/06/18 MAS	Added a skeleton PulseOutput() function for
+				which will be responsible for interpreting output
+				counter pulses and forwarding decoded info.
 */
 
 #include <errno.h>
@@ -418,6 +421,13 @@ ChannelInput (agc_t *State)
     }
   return (0);
 }
+
+void
+PulseOutput(agc_t * State, int SignalId)
+{
+  // FIXME: Implement me!
+}
+
 
 //----------------------------------------------------------------------
 // A generic function for handling client connects/disconnects.

--- a/yaAGC/agc_cli.c
+++ b/yaAGC/agc_cli.c
@@ -36,6 +36,8 @@
  *              08/04/16 OH     Fixed the GPL statement and old user-id
  *              09/30/16 MAS    Added the --inhibit-alarms option
  *              05/30/17 RSB	Added --initialize-sunburst-37 option.
+ *              01/28/18 MAS	Removed help text stating that only ropes
+ *                          	with 36 banks are expected/supported.
  */
 
 #include <string.h>
@@ -101,14 +103,7 @@ static void CliShowUsage(void)
 "                         for a first-time run of SUNBURST 37 (SHEPATIN 0) having\n"
 "                         otherwise clean memory, in lieu of pad-loads.  Not\n"
 "                         required for subsequent runs.  Note that this option only\n"
-"                         has an effect if there is no existing core-dump file.\n"
-"Note that the exec-ropes file should contain exactly 36 banks\n"
-"(36x1024=36864 words, or 73728 bytes). Other sizes may be accepted,\n"
-"but it is unclear what (if any) utility such core-rope images\n"
-"would have. (In particular, if the core-rope\n"
-"is supposed to be for actual Luminary or Colossus software, then\n"
-"the checksums of the missing memory banks would be incorrect, and\n"
-"so the built-in self-test would fail.)\n\n");
+"                         has an effect if there is no existing core-dump file.\n");
 }
 
 extern FILE *rfopen (const char *Filename, const char *mode);

--- a/yaAGC/agc_debugger.c
+++ b/yaAGC/agc_debugger.c
@@ -43,6 +43,10 @@
 	        01/29/17 MAS    Switched off the infinite loop check if
                                 alarms aren't inhibited (so the TC Trap
                                 can do its thing).
+	        01/28/18 MAS    Made the halt check logic look at
+                                PendDelay instead of PendFlag, since
+                                PendFlag is no longer used.
+
  */
 
 #include <stdio.h>
@@ -192,7 +196,7 @@ DbgHasBreakEvent ()
 {
   int BreakFlag = 0;
 
-  if (Debugger.State->PendFlag)
+  if (Debugger.State->PendDelay > 0)
     BreakFlag = 0;
   else
     {
@@ -1391,7 +1395,7 @@ DbgExecute ()
 		      Breakpoints[j].WatchValue = DbgGetWatch (Debugger.State,
 							       &Breakpoints[j]);
 		}
-	      Debugger.State->PendFlag = SingleStepCounter = 0;
+	      SingleStepCounter = 0;
 	      Break = 1;
 	      SimSetCycleCount (SIM_CYCLECOUNT_AGC);
 

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -427,6 +427,9 @@
  *		                The "both inputs" case for each PIPA axis is not
  *		                checked, under the assumption that the simulated
  *		                PIPA would not be implemented to ever do this.
+ *		03/12/18 MAS	Switched the radar interface to generate sync
+ *		                pulse outputs, which trigger shifting in of
+ *		                data via PulseInput.
  *
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,
@@ -1720,13 +1723,10 @@ TimingSignalF05A(agc_t * State)
     // Generate radar count requests if a valid radar is selected
     if (State->RadarSync)
     {
-        if (State->RadarData & 040000)
-          PulseType = COUNTER_CELL_ONE;
-        else
-          PulseType = COUNTER_CELL_ZERO;
-
-        CounterRequest(State, COUNTER_RNRAD, PulseType);
-        State->RadarData <<= 1;
+        if (State->InputChannel[013] & 04)
+            PulseOutput(State, OUTPUT_LR_SYNC);
+        else if ((State->InputChannel[013] & 03) != 0)
+            PulseOutput(State, OUTPUT_RR_SYNC);
     }
 
     // Generate gyro drive pulses

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -422,6 +422,11 @@
  *		                Also added some initial support code for INLINK,
  *		                and switched all output counters to using the
  *		                new PulseOutput() interface.
+ *		02/25/18 MAS	Put in simulation of PIPA data strobes as well as
+ *		                most of the the PIPA failure monitoring logic.
+ *		                The "both inputs" case for each PIPA axis is not
+ *		                checked, under the assumption that the simulated
+ *		                PIPA would not be implemented to ever do this.
  *
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,
@@ -1403,15 +1408,16 @@ CounterSHINC (agc_t * State, int Counter)
   int16_t i;
   i = State->Erasable[0][RegCOUNTER + Counter];
 
-  // OUTLINK and ALTM counters generate output pulses depending
-  // on whether or not a one is being shifted off the top
   switch (Counter)
     {
+  // INLINK generates an UPRUPT if a one is shifted off the top
     case COUNTER_INLINK:
       if (i & 040000)
         State->InterruptRequests[RUPT_UPRUPT] = 1;
       break;
 
+  // OUTLINK and ALTM counters generate output pulses depending
+  // on whether or not a one is being shifted off the top
     case COUNTER_OUTLINK:
       if (i & 040000)
         PulseOutput(State, OUTPUT_OUTLINK_ONE);
@@ -1614,7 +1620,8 @@ SimulateDV(agc_t *State, uint16_t divisor)
 static void
 TimingSignalF03B(agc_t * State)
 {
-    // if FS04 && !FS05, generate PIPA count requests
+    if ((State->ScalerValue & (SCALER_FS05 | SCALER_FS04)) == SCALER_FS04)
+      PulseOutput(State, OUTPUT_PIPA_DATA);
 }
 
 // Timepulse F04A clears the uplink-too-fast bit, which is set by each
@@ -1675,6 +1682,11 @@ TimingSignalF05A(agc_t * State)
     // That's it for standby-powered stuff, so leave if we're in standby
     if (State->Standby)
         return CausedRestart;
+
+    // Set the PIPA pulse missing monitoring bits for each PIPA
+    State->PipaMissX = 1;
+    State->PipaMissY = 1;
+    State->PipaMissZ = 1;
 
     // Check for any of the input traps to be triggered. If they are, and
     // the cause of the triggering doesn't go away before F05B, we'll
@@ -1843,6 +1855,10 @@ TimingSignalF05B(agc_t * State)
 
     if (State->Standby)
         return;
+
+    // Set the PIPA fail bit if any expected PIPA pulses were not received
+    if (State->PipaMissX || State->PipaMissY || State->PipaMissZ)
+      State->InputChannel[033] &= ~010000;
 
     // If any of the input traps are pending, generate a HANDRUPT and
     // disable the tripped trap.
@@ -2260,6 +2276,12 @@ TimingSignalF17B(agc_t * State)
 static void
 TimingSignalF18A(agc_t * State)
 {
+    State->PipaNoXPlus = 1;
+    State->PipaNoXMinus = 1;
+    State->PipaNoYPlus = 1;
+    State->PipaNoYMinus = 1;
+    State->PipaNoZPlus = 1;
+    State->PipaNoZMinus = 1;
 }
 
 // Timepulse F18B marks the end of the monitoring period for loss of
@@ -2267,6 +2289,10 @@ TimingSignalF18A(agc_t * State)
 static void
 TimingSignalF18B(agc_t * State)
 {
+    if (State->PipaNoXPlus || State->PipaNoXMinus ||
+        State->PipaNoYPlus || State->PipaNoYMinus ||
+        State->PipaNoZPlus || State->PipaNoZMinus)
+      State->InputChannel[033] &= ~010000;
 }
 
 //-----------------------------------------------------------------------------
@@ -2487,6 +2513,10 @@ int HandleNextCounterCell(agc_t * State)
 
     // SHINC/SHANC. SHANC takes priority if both are requested.
     case COUNTER_INLINK:
+        // INLINK counts set the uplink-too-fast flip-flop, which prevent
+        // any further counts until after the next F04A. The remaining
+        // logic is identical to RNRAD.
+        State->UplinkTooFast = 1;
     case COUNTER_RNRAD:
         if (State->CounterCell[i] & COUNTER_CELL_ONE)
             CounterSHANC(State, i);

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -139,6 +139,8 @@
 				of input signal definitions for use with the new
 				PulseInput(), which is intended to complement the
 				PulseOutput() function.
+		03/12/18 MAS	Corrected some pin mappings and deleted the
+				placeholder RadarData from State.
  
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -377,14 +379,16 @@ extern long random (void);
 #define OUTPUT_OPTYCMD_PLUS  336
 #define OUTPUT_OPTXCMD_MINUS 337
 #define OUTPUT_OPTXCMD_PLUS  338
+#define OUTPUT_LR_SYNC       340
+#define OUTPUT_RR_SYNC       346
 #define OUTPUT_EMSD_MINUS    349
 #define OUTPUT_EMSD_PLUS     350
 #define OUTPUT_THRUST_MINUS  353
 #define OUTPUT_THRUST_PLUS   354
-#define OUTPUT_ALTRATE_ZERO  455
-#define OUTPUT_ALTRATE_ONE   456
-#define OUTPUT_ALT_ZERO      457
-#define OUTPUT_ALT_ONE       458
+#define OUTPUT_ALTRATE_ZERO  355
+#define OUTPUT_ALTRATE_ONE   356
+#define OUTPUT_ALT_ZERO      357
+#define OUTPUT_ALT_ONE       358
 #define OUTPUT_OUTLINK_ONE   517
 #define OUTPUT_OUTLINK_ZERO  518
 
@@ -395,8 +399,8 @@ extern long random (void);
 #define INPUT_CROSSLINK_ZERO 123
 #define INPUT_LR_ONE         124
 #define INPUT_LR_ZERO        125
-#define INPUT_LR_ONE         126
-#define INPUT_LR_ZERO        127
+#define INPUT_RR_ONE         126
+#define INPUT_RR_ZERO        127
 #define INPUT_UPLINK_ONE     128
 #define INPUT_UPLINK_ZERO    129
 #define INPUT_DOWNLINK_SYNC  130
@@ -625,7 +629,6 @@ typedef struct
   int RHCVoltagemV[3];
   int RHCCounts[3];
   uint8_t RadarGateCounter;
-  uint16_t RadarData;
   uint8_t PipaPrecount[3];
   // The following pointer is present for whatever use the Orbiter
   // integration squad wants.  The Virtual AGC code proper doesn't use it

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -128,7 +128,8 @@
 				are simulating the later AGCs, with 42 max.
 		01/31/18 MAS	Added state fields for radar simulation, as well
 				as defines for interrupt indexes.
-		02/01/18 MAS	Added state fields for gyro drive simulation.
+		02/01/18 MAS	Added state fields for gyro drive and CDU drive
+				simulation.
  
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -541,6 +542,7 @@ typedef struct
   uint8_t RadarGateCounter;
   uint16_t RadarData;
   uint16_t GyroDriveOut;
+  int CduDriveOut[5];
   // The following pointer is present for whatever use the Orbiter
   // integration squad wants.  The Virtual AGC code proper doesn't use it
   // in any way.

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -130,6 +130,7 @@
 				as defines for interrupt indexes.
 		02/01/18 MAS	Added state fields for gyro drive and CDU drive
 				simulation.
+		02/02/18 MAS	Added state fields for THRUST and EMSD counters.
  
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -527,6 +528,10 @@ typedef struct
   unsigned RHCPending:1;
   unsigned RadarSync:1;
   unsigned GyroDriveActive:1;
+  unsigned ThrustPlusActive:1;
+  unsigned ThrustMinusActive:1;
+  unsigned EMSPlusActive:1;
+  unsigned EMSMinusActive:1;
   uint8_t CounterCell[NUM_COUNTERS]; // Counter cells storing requested plus or minus counts
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
@@ -543,6 +548,8 @@ typedef struct
   uint16_t RadarData;
   uint16_t GyroDriveOut;
   int CduDriveOut[5];
+  int ThrustOut;
+  int EMSOut;
   // The following pointer is present for whatever use the Orbiter
   // integration squad wants.  The Virtual AGC code proper doesn't use it
   // in any way.

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -128,6 +128,7 @@
 				are simulating the later AGCs, with 42 max.
 		01/31/18 MAS	Added state fields for radar simulation, as well
 				as defines for interrupt indexes.
+		02/01/18 MAS	Added state fields for gyro drive simulation.
  
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -524,6 +525,7 @@ typedef struct
   unsigned MarkruptPending:1;   // Flag indicating a MARK key is pressed and an interrupt may occur
   unsigned RHCPending:1;
   unsigned RadarSync:1;
+  unsigned GyroDriveActive:1;
   uint8_t CounterCell[NUM_COUNTERS]; // Counter cells storing requested plus or minus counts
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
@@ -538,6 +540,7 @@ typedef struct
   int RHCCounts[3];
   uint8_t RadarGateCounter;
   uint16_t RadarData;
+  uint16_t GyroDriveOut;
   // The following pointer is present for whatever use the Orbiter
   // integration squad wants.  The Virtual AGC code proper doesn't use it
   // in any way.

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -131,6 +131,7 @@
 		02/01/18 MAS	Added state fields for gyro drive and CDU drive
 				simulation.
 		02/02/18 MAS	Added state fields for THRUST and EMSD counters.
+		02/02/18 MAS	Added state fields for OUTLINK and ALTM counters.
  
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -532,6 +533,10 @@ typedef struct
   unsigned ThrustMinusActive:1;
   unsigned EMSPlusActive:1;
   unsigned EMSMinusActive:1;
+  unsigned OutlinkActive:1;
+  unsigned OutlinkStarting:1;
+  unsigned AltActive:1;
+  unsigned AltStarting:1;
   uint8_t CounterCell[NUM_COUNTERS]; // Counter cells storing requested plus or minus counts
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
@@ -550,6 +555,9 @@ typedef struct
   int CduDriveOut[5];
   int ThrustOut;
   int EMSOut;
+  uint16_t OutlinkOut;
+  uint16_t AltOut;
+  uint16_t AltRateOut;
   // The following pointer is present for whatever use the Orbiter
   // integration squad wants.  The Virtual AGC code proper doesn't use it
   // in any way.

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -131,7 +131,10 @@
 		02/01/18 MAS	Added state fields for gyro drive and CDU drive
 				simulation.
 		02/02/18 MAS	Added state fields for THRUST and EMSD counters.
-		02/02/18 MAS	Added state fields for OUTLINK and ALTM counters.
+		02/02/18 MAS	Added state fields for OUTLINK and ALTM counters,
+				removed the placeholder state fields for holding
+				outputs, and added IDs for the various output
+				counter signals for use with PulseOutput().
  
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -354,6 +357,32 @@ extern long random (void);
 #define RUPT_HANDRUPT 10
 #define NUM_INTERRUPT_TYPES 10
 
+// Pulse output signals (numbered according to AGC main connector
+// pin numbers, which should hopefully make cross-referencing these
+// signals with the LM Systems Handbook easier). The outlink and
+// EMSD pins are guesses, since the interfaces weren't used.
+#define OUTPUT_OUTLINK_ZERO  122
+#define OUTPUT_OUTLINK_ONE   123
+#define OUTPUT_GYROCMD_SET   318
+#define OUTPUT_CDUZCMD_MINUS 328
+#define OUTPUT_CDUZCMD_PLUS  329
+#define OUTPUT_CDUYCMD_MINUS 330
+#define OUTPUT_CDUYCMD_PLUS  332
+#define OUTPUT_CDUXCMD_MINUS 333
+#define OUTPUT_CDUXCMD_PLUS  334
+#define OUTPUT_OPTYCMD_MINUS 335
+#define OUTPUT_OPTYCMD_PLUS  336
+#define OUTPUT_OPTXCMD_MINUS 337
+#define OUTPUT_OPTXCMD_PLUS  338
+#define OUTPUT_EMSD_MINUS    349
+#define OUTPUT_EMSD_PLUS     350
+#define OUTPUT_THRUST_MINUS  353
+#define OUTPUT_THRUST_PLUS   354
+#define OUTPUT_ALTRATE_ZERO  455
+#define OUTPUT_ALTRATE_ONE   456
+#define OUTPUT_ALT_ZERO      457
+#define OUTPUT_ALT_ONE       458
+
 // Max number of 15-bit words in a downlink-telemetry list.
 #define MAX_DOWNLINK_LIST 260
 
@@ -537,6 +566,7 @@ typedef struct
   unsigned OutlinkStarting:1;
   unsigned AltActive:1;
   unsigned AltStarting:1;
+  unsigned UplinkTooFast:1;
   uint8_t CounterCell[NUM_COUNTERS]; // Counter cells storing requested plus or minus counts
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
@@ -551,13 +581,6 @@ typedef struct
   int RHCCounts[3];
   uint8_t RadarGateCounter;
   uint16_t RadarData;
-  uint16_t GyroDriveOut;
-  int CduDriveOut[5];
-  int ThrustOut;
-  int EMSOut;
-  uint16_t OutlinkOut;
-  uint16_t AltOut;
-  uint16_t AltRateOut;
   // The following pointer is present for whatever use the Orbiter
   // integration squad wants.  The Virtual AGC code proper doesn't use it
   // in any way.
@@ -729,6 +752,7 @@ void ChannelOutput (agc_t * State, int Channel, int Value);
 int ChannelInput (agc_t * State);
 void ChannelRoutine (agc_t *State);
 void ChannelRoutineGeneric (void *State, void (*UpdatePeripherals) (void *, Client_t *));
+void PulseOutput(agc_t * State, int SignalId);
 void ShiftToDeda (agc_t *State, int Data);
 
 #endif // AGC_ENGINE_H

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -97,6 +97,8 @@
  * 		01/31/18 MAS	Added initialization for radar state info.
  * 		02/01/18 MAS	Added initialization for gyro drive and CDU drive
  *                              state info.
+ * 		02/01/18 MAS	Added initialization for THRUST and EMSD counter
+ *                              state info.
  */
 
 // For Orbiter.
@@ -354,6 +356,14 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
 
   for (i = 0; i < 5; i++)
     State->CduDriveOut[i] = 0;
+
+  State->ThrustPlusActive = 0;
+  State->ThrustMinusActive = 0;
+  State->ThrustOut = 0;
+
+  State->EMSPlusActive = 0;
+  State->EMSMinusActive = 0;
+  State->EMSOut = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -95,6 +95,7 @@
  *                              state variables.
  * 		01/30/18 MAS	Added initialization for RHC state info.
  * 		01/31/18 MAS	Added initialization for radar state info.
+ * 		02/01/18 MAS	Added initialization for gyro drive state info.
  */
 
 // For Orbiter.
@@ -346,6 +347,9 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->RadarGateCounter = 0;
   State->RadarData = 0;
   State->RadarSync = 0;
+
+  State->GyroDriveActive = 0;
+  State->GyroDriveOut = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -351,7 +351,6 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
     }
 
   State->RadarGateCounter = 0;
-  State->RadarData = 0;
   State->RadarSync = 0;
 
   State->GyroDriveActive = 0;

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -95,7 +95,8 @@
  *                              state variables.
  * 		01/30/18 MAS	Added initialization for RHC state info.
  * 		01/31/18 MAS	Added initialization for radar state info.
- * 		02/01/18 MAS	Added initialization for gyro drive state info.
+ * 		02/01/18 MAS	Added initialization for gyro drive and CDU drive
+ *                              state info.
  */
 
 // For Orbiter.
@@ -340,8 +341,8 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->RHCPending = 0;
   for (i = 0; i < 3; i++)
     {
-      State->RHCVoltagemV[0] = 0;
-      State->RHCCounts[0] = 0;
+      State->RHCVoltagemV[i] = 0;
+      State->RHCCounts[i] = 0;
     }
 
   State->RadarGateCounter = 0;
@@ -350,6 +351,9 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
 
   State->GyroDriveActive = 0;
   State->GyroDriveOut = 0;
+
+  for (i = 0; i < 5; i++)
+    State->CduDriveOut[i] = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -101,6 +101,7 @@
  *                              state info.
  * 		02/01/18 MAS	Added initialization for OUTLINK and ALTM counter
  *                              state info, and removed some old placeholders.
+ * 		02/12/18 MAS	Added initialization for PIPA state info.
  */
 
 // For Orbiter.
@@ -368,6 +369,18 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->AltStarting = 0;
 
   State->UplinkTooFast = 0;
+
+  State->PipaMissX = 0;
+  State->PipaMissY = 0;
+  State->PipaMissZ = 0;
+  State->PipaNoXPlus = 0;
+  State->PipaNoXMinus = 0;
+  State->PipaNoYPlus = 0;
+  State->PipaNoYMinus = 0;
+  State->PipaNoZPlus = 0;
+  State->PipaNoZMinus = 0;
+  for (i = 0; i < 3; i++)
+    State->PipaPrecount[i] = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -99,6 +99,8 @@
  *                              state info.
  * 		02/01/18 MAS	Added initialization for THRUST and EMSD counter
  *                              state info.
+ * 		02/01/18 MAS	Added initialization for OUTLINK and ALTM counter
+ *                              state info.
  */
 
 // For Orbiter.
@@ -364,6 +366,15 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->EMSPlusActive = 0;
   State->EMSMinusActive = 0;
   State->EMSOut = 0;
+
+  State->OutlinkActive = 0;
+  State->OutlinkStarting = 0;
+  State->OutlinkOut = 0;
+
+  State->AltActive = 0;
+  State->AltStarting = 0;
+  State->AltOut = 0;
+  State->AltRateOut = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -93,6 +93,7 @@
  * 		07/13/17 MAS	Added initialization of the three HANDRUPT traps.
  * 		01/28/18 MAS	Added initialization for the new counter and scaler
  *                              state variables.
+ * 		01/30/18 MAS	Added initialization for RHC state info.
  */
 
 // For Orbiter.
@@ -334,6 +335,13 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
 
   State->AutoClearKeys = 1;
 
+  State->RHCPending = 0;
+  for (i = 0; i < 3; i++)
+    {
+      State->RHCVoltagemV[0] = 0;
+      State->RHCCounts[0] = 0;
+    }
+
   if (initializeSunburst37)
     {
       State->Erasable[0][0067] = 077777;
@@ -347,6 +355,7 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
       cd = fopen (CoreDump, "r");
       if (cd == NULL)
 	{
+          PerformGOJAM(State);
 	  if (AllOrErasable)
 	    RetVal = 6;
 	  else

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -100,7 +100,7 @@
  * 		02/01/18 MAS	Added initialization for THRUST and EMSD counter
  *                              state info.
  * 		02/01/18 MAS	Added initialization for OUTLINK and ALTM counter
- *                              state info.
+ *                              state info, and removed some old placeholders.
  */
 
 // For Orbiter.
@@ -354,27 +354,20 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->RadarSync = 0;
 
   State->GyroDriveActive = 0;
-  State->GyroDriveOut = 0;
-
-  for (i = 0; i < 5; i++)
-    State->CduDriveOut[i] = 0;
 
   State->ThrustPlusActive = 0;
   State->ThrustMinusActive = 0;
-  State->ThrustOut = 0;
 
   State->EMSPlusActive = 0;
   State->EMSMinusActive = 0;
-  State->EMSOut = 0;
 
   State->OutlinkActive = 0;
   State->OutlinkStarting = 0;
-  State->OutlinkOut = 0;
 
   State->AltActive = 0;
   State->AltStarting = 0;
-  State->AltOut = 0;
-  State->AltRateOut = 0;
+
+  State->UplinkTooFast = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -94,6 +94,7 @@
  * 		01/28/18 MAS	Added initialization for the new counter and scaler
  *                              state variables.
  * 		01/30/18 MAS	Added initialization for RHC state info.
+ * 		01/31/18 MAS	Added initialization for radar state info.
  */
 
 // For Orbiter.
@@ -341,6 +342,10 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
       State->RHCVoltagemV[0] = 0;
       State->RHCCounts[0] = 0;
     }
+
+  State->RadarGateCounter = 0;
+  State->RadarData = 0;
+  State->RadarSync = 0;
 
   if (initializeSunburst37)
     {


### PR DESCRIPTION
Here's the first pass at refactoring for correct execution priority and counter support, as laid out in #1055. The scaler logic had become an unsightly pile of spaghetti, so I've greatly cleaned it up and broken it out from agc_engine(). It should be much, much easier to follow now for anybody referencing schematics or ND-1021042.

Counters are now tracked via an array of "counter cells", which can store either plus or minus requests for any individual counter. The cells are processed in priority order, and handle cases of both requests (franken-instructions) correctly. Everything internal has been moved over to the new system and appears to be working.

I took the opportunity to clean up a lot of cruft, and some of it may or may not find its way back in (trappipa, cdulog, etc.) as I go through adding in the unique logic for each counter.

As it stands, all of the tests contained in Borealis still pass, standby operates as it is supposed to, and everything generally seems working. I still need to do more testing, though.

I made a variety of other changes working through the above:
 * Added input voltage monitoring and voltage alarm simulation for use by NASSP and other integrated spacecraft simulations.
 * Added both halves of the counter alarm (only count instructions executed, or one not executed immediately after being requested).
 * Reorganized the order of operations in agc_engine() so all activities have the correct priority -- GOJAM > counts > rupts > instructions.
 * Made INHINT, RELINT, and EXTEND prevent counts or interrupts from happening if they are the next instruction to be executed, since they are really "pseudo-instructions" that extend the length of the preceding instruction by 1 MCT.
 * Moved instruction effects ot the first MCT, rather than the last, for multi-MCT instructions.  This is much closer to the truth, generally, and makes priority simulation easier.
 * Made BZF and BZMF take an extra MCT if their branches are not taken, which we had missed.

Next up is implementing each of the counters themselves. I'm going to start with the RHC circuits, since they are pretty interesting and the interface to NASSP is very straightforward (they provide a voltage level from the RHC, and the AGC internally converts that to a number of pulses).