### PR TITLE
Explain core memory size.

### DIFF
--- a/assembly_language_manual.html
+++ b/assembly_language_manual.html
@@ -154,7 +154,7 @@
     software needed for the mission was encoded in the "core ropes", and
     these had to be manufactured and hermetically sealed within the
     computer unit. In other words, all of the software needed to fit
-    within the 38,912 15-bit words of core memory.<br>
+    within the 38,912 15-bit words of core memory (36K of core rope and 2K of RAM).<br>
     <br>
     To solve this problem, the designers of the AGC chose to use part of
     the precious core memory to implement a virtual


### PR DESCRIPTION
The text here confused Wikipedia, leading to the wrong core rope size on the AGC page.