### PR TITLE
Retread 50: Completed disassembly of new extended verbs

### DIFF
--- a/Retread50/ERASABLE_ASSIGNMENTS.agc
+++ b/Retread50/ERASABLE_ASSIGNMENTS.agc
@@ -7,6 +7,7 @@
 ## Website:     www.ibiblio.org/apollo/Restoration.html
 ## Mod history: 2019-06-12 MAS  Recreated from Computer History Museum's
 ##				physical core-rope modules.
+##              2019-10-01 MAS  Assigned names to the UNK12xx erasables.
 
 ## Page 5
 
@@ -355,12 +356,15 @@ SMODE		ERASE
                 SETLOC          1200
 CDUIND          ERASE
 ITEMP1          ERASE
-COMMAND         ERASE
-                SETLOC          1205
-UNK1205         ERASE
-UNK1206         ERASE
-UNK1207         ERASE
-UNK1210         ERASE
+COMMAND         ERASE           +2
+
+GYRONUM         ERASE
+GYCMDIDX        ERASE           +1
+
+# GYRO PULSE TORQUE COMMANDS
+OGC             ERASE           +1
+MGC             ERASE           +1
+IGC             ERASE           +1
 ## !! END CHANGE FOR RETREAD 50 !!
 
 

--- a/Retread50/MAIN.agc
+++ b/Retread50/MAIN.agc
@@ -6,8 +6,9 @@
 # Contact:     Ron Burkey <info@sandroid.org>.
 # Website:     www.ibiblio.org/apollo/Restoration.html
 # Mod history: 2019-06-12 MAS  Created.
+#              2019-10-01 MAS  Updated for completed disassembly.
 #               
-# MAIN.agc is a little different from the other Retread44 files  
+# MAIN.agc is a little different from the other Retread50 files  
 # provided, in that it doesn't represent anything that appears 
 # directly in the original source.  What we have done for 
 # organizational purposes is to split the huge monolithic source 
@@ -33,6 +34,6 @@ $T4RUPT_PROGRAM.agc                    # 128
 $KEYRUPT,_UPRUPT.agc                   # 131
 $PINBALL_GAME__BUTTONS_AND_LIGHTS.agc  # 135
 $AGC_BLK2_INSTRUCTION_CHECK.agc        # 210
-$BANK11.agc                            # 210
+$EXTENDED_VERBS_FOR_MODING.agc         # 243
 
-#Assembly-tables                       # 243
+#Assembly-tables                       # 244+

--- a/Retread50/Main.annotation
+++ b/Retread50/Main.annotation
@@ -13,8 +13,9 @@ and AURORA 12. <a href="http://www.ibiblio.org/apollo/Restoration.html">
 <u>Read about the process here.</u></a>  Assembling this source code with
 yaYUL produces core ropes identical to those of the physical modules. 
 Page-number references refer to corresponding sections of RETREAD 44 source
-code.  No printouts of RETREAD 50 program listings are available.  Names of
-variables and program constants of the form "UNK<i>nnnn</i>" appear in areas not yet correlated
-with other pre-existing source code, and which are therefore unknown.
+code.  No printouts of RETREAD 50 program listings are available.  New sections of the
+software (appearing in EXTENDED_VERBS_FOR_MODING.agc) have been disassembled; labels
+and comments have been either taken from similar code in later programs or, in cases
+where this was not possible, added by VirtualAGC for clarity.
 </td></tr></tbody></table>
 

--- a/Retread50/VERB_AND_NOUN_INFORMATION.agc
+++ b/Retread50/VERB_AND_NOUN_INFORMATION.agc
@@ -7,6 +7,7 @@
 ## Website:     www.ibiblio.org/apollo/Restoration.html
 ## Mod history: 2019-06-12 MAS  Recreated from Computer History Museum's
 ##				physical core-rope modules.
+##              2019-10-01 MAS  Added Retread 50's new extended verbs.
 
 ## Page 1
 
@@ -48,6 +49,17 @@
 # 36  FRESH START
 # 37  CHANGE MAJOR MODE
 # END OF REGULAR VERBS
+
+## !! START CHANGE FOR RETREAD 50 !!
+
+# EXTENDED VERBS
+# 40  ZERO ISS CDU
+# 41  COARSE ALIGN IMU
+# 42  FINE ALIGN IMU
+# 43  PULSE TORQUE GYROS
+# 44  ISS TURN-ON
+
+## !! END CHANGE FOR RETREAD 50 !!
 
 ## Page 3
 # NORMAL NOUNS                                       SCALE AND DECIMAL POINT


### PR DESCRIPTION
I've decided to take a bit of a break from reconstruction and spend some time focusing on all of the rope modules we've dumped recently. To kick things off, I went back to Retread 50 and finished off the disassembly of the new stuff in bank 11. No more pesky UNKxxxx labels!

It turns out a lot of it was able to be correlated to various chunks of code in Aurora, just to a lesser extent than the stuff I already had done. The only thing that was still almost entirely different from other things we have was Verb 43, for gyro pulse torquing. To help with the disassembly, I created a flowchart of how it works (matching the MIT flowcharts style as closely as I could):
![Retread 50 Pulse Torque Flowcharts (5)](https://user-images.githubusercontent.com/94056/66020333-9d33eb00-e49b-11e9-8adb-10fa34b15a00.png)

To use this verb, you apparently have to manually enter three double-precision numbers into location 1210 (which I've guessed was named "OGC"), for the outer, middle, and inner gyro commands, in that order. You then invoke verb 43, which will send the correct amount of pulses to each gyro.

I also changed the name of the section from BANK11.agc to EXTENDED_VERBS_FOR_MODING.agc, which is what Solarium has. I went with this since Solarium is the closest rope we have in time to Retread, and all of the new verbs are related to IMU moding.

Let me know if any of the changes are unclear, or if you have better suggestions for names of things.