### PR TITLE
CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,16 @@ set(NVER \\\"2019-09-22\\\")
 add_subdirectory(yaAGC)
 add_subdirectory(yaDSKY2)
 add_subdirectory(yaYUL)
+
+## install to ~/VirtualAGC upon:
+# cmake --build build --target install
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  if(WIN32)
+    set(HOME $ENV{USERPROFILE})
+  else()
+    set(HOME $ENV{HOME})
+  endif()
+
+  set(CMAKE_INSTALL_PREFIX "${HOME}/VirtualAGC" CACHE PATH "..." FORCE)
+endif()

--- a/yaAGC/CMakeLists.txt
+++ b/yaAGC/CMakeLists.txt
@@ -16,8 +16,9 @@ if(Threads_FOUND)
   target_link_libraries(yaAGC Threads::Threads)
 endif()
 
-
 if(WIN32)
   target_sources(yaAGC PRIVATE regex.c random.c)
   target_link_libraries(yaAGC wsock32)
 endif()
+
+install(TARGETS yaAGC)

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -137,6 +137,8 @@ extern "C" {
 #define NULL ((void *) 0)
 #endif
 
+#include <stdio.h>
+
 // The following is used to get the int16_t datatype.
 #ifdef WIN32
 // Win32

--- a/yaDSKY2/CMakeLists.txt
+++ b/yaDSKY2/CMakeLists.txt
@@ -13,6 +13,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC/rfopen.c)
 add_executable(${APPNAME} ${SOURCES} ${SOURCESc})
 target_include_directories(${APPNAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC)
 target_compile_definitions(${APPNAME} PRIVATE NVER="${NVER}")
+
 if(WIN32)
   target_link_libraries(${APPNAME} wsock32)
 endif()
@@ -36,3 +37,12 @@ else()
   separate_arguments(wxWidgets_LIBRARIES)
   target_link_libraries(${APPNAME} PRIVATE ${wxWidgets_LIBRARIES})
 endif()
+
+# --- install
+
+install(TARGETS ${APPNAME})
+
+# must have trailing /
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+  DESTINATION bin
+  FILES_MATCHING PATTERN "*.jpg" PATTERN "*.png")

--- a/yaDSKY2/CMakeLists.txt
+++ b/yaDSKY2/CMakeLists.txt
@@ -12,6 +12,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC/rfopen.c)
 
 add_executable(${APPNAME} ${SOURCES} ${SOURCESc})
 target_include_directories(${APPNAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC)
+target_compile_definitions(${APPNAME} PRIVATE NVER="${NVER}")
 if(WIN32)
   target_link_libraries(${APPNAME} wsock32)
 endif()

--- a/yaYUL/CMakeLists.txt
+++ b/yaYUL/CMakeLists.txt
@@ -16,3 +16,5 @@ add_executable(yaYUL ${CFILES})
 target_compile_options(yaYUL PRIVATE ${CFLAGS})
 target_link_libraries(yaYUL PRIVATE m)
 target_compile_definitions(yaYUL PRIVATE NVER="${NVER}")
+
+install(TARGETS yaYUL)


### PR DESCRIPTION
added metadata to CMake so that existing targets are installable in user directory ~/VirtualAGC upon

```sh
cmake --build build --target install
```

for CMake, it's considered an anti-pattern to copy files outside the build directory without the command above.
So a fresh new user would do:

```sh
cmake -B build
cmake --build build --target install
```

to configure, compile and install from scratch