### PR TITLE
Fix various symbol name and other minor typos

### DIFF
--- a/Comanche055/ANGLFIND.agc
+++ b/Comanche055/ANGLFIND.agc
@@ -15,6 +15,8 @@
 ##				CADR ZEROEROR.
 ##		2017-01-07 RSB	Fixed comment errors detected in cross-diff vs
 ##				Colossus 237 and Colossus 249.
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
 ##
 ## This source code has been transcribed or otherwise adapted from digitized
 ## images of a hardcopy from the MIT Museum.  The digitization was performed
@@ -425,7 +427,7 @@ LOOPSIN		SLOAD*	RTB
 		STADR
 		STORE	16D,2		# C8=-SIN(THETA)SIN(PHI)SIN(PSI)
 		RVQ			#    +COS(THETA)COS(PHI)
-ENDOCM		EQUALS
+ENDDCM		EQUALS
 
 		BANK	15
 		SETLOC	KALCMON1
@@ -622,7 +624,7 @@ VECOFANG	VDEF	RVQ
 
 NOGOM2		INHINT			# THIS LOCATION ACCESSED BY A BZMF NOGO -2
 		TC	BANKCALL
-		CADR	ZEROERROR
+		CADR	ZEROEROR
 		
 NOGO		INHINT
 		TC	STOPRATE

--- a/Comanche055/ERASABLE_ASSIGNMENTS.agc
+++ b/Comanche055/ERASABLE_ASSIGNMENTS.agc
@@ -32,7 +32,9 @@
 ##		2017-01-22 RSB	Fixed comment errors detected in cross-diff vs
 ##				Artemis 72.
 ##		2017-03-16 RSB	Fixed a ##-style comment.
-
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
+##
 ## This source code has been transcribed or otherwise adapted from digitized
 ## images of a hardcopy from the MIT Museum.  The digitization was performed
 ## by Paul Fjeld, and arranged for by Deborah Douglas of the Museum.  Many
@@ -984,7 +986,7 @@ ENDSPBIT	=	BIT13
 CMDAPARM	=	093D		# ALOW ENTRY FIRINGS	INHIBIT ENTRY FIRING
 					# AND CALCULATIONS	AND CONTROL FUNCTION
 ## Page 58					
-CMDARMBIT	=	BIT12
+CMARMBIT	=	BIT12
 
 # BIT 11 FLAG 6
 GAMDIFSW	=	094D		# CALCULATE GAMDOT	GAMDOT NOT TO BE
@@ -1237,7 +1239,7 @@ COGAFBIT	=	BIT4
 ## Page 63
 V96ONFLG	=	132D		# P00 INTEGRATION HAS	P00 INTEGRATION IS
 					# BEEN INHIBITED BY	PROCEEDING REGULARLY
-					# V96
+V96ONBIT        =       BIT3		# V96
 		
 # BIT 2 FLAG 8
 #		=	133D
@@ -3268,7 +3270,7 @@ TTEMP		EQUALS	TMIS	+4	# B   TMP
 KV2		EQUALS	TMIS	+6	# I(6)TMP
 BIASTEMP	EQUALS	TMIS	+6	# B   TMP
 KV3		EQUALS	TMIS	+12D	# I(6)TMP
-CGF		EQUALS	TMIS	+12D	# I   TMP
+OGF		EQUALS	TMIS	+12D	# I   TMP
 
 BRATE		EQUALS	COFSKEW		# B   TMP
 TM		EQUALS	CAM		# B   TMP

--- a/Comanche055/FRESH_START_AND_RESTART.agc
+++ b/Comanche055/FRESH_START_AND_RESTART.agc
@@ -20,6 +20,8 @@
 ##		2017-01-28 RSB	WTIH -> WITH.
 ##		2017-03-13 RSB	GOP00FIX -> GOPOOFIX.
 ##		2017-08-19 MAS	Fixed label errors found transcribing Zerlina 56.
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
 ##
 ## The contents of the "Comanche055" files, in general, are transcribed
 ## from scanned documents.
@@ -1227,7 +1229,7 @@ NEG7		EQUALS	OCT77770
 OCT44571	OCT	44571			# CONSTANTS TO CLEAR CHANNEL BITS IN V37
 OCT600		OCT	600
 		EBANK=	PACTOFF
-P00DAPAD	2CADR	T5IDLOC
+POODAPAD	2CADR	T5IDLOC
 
 MMTEMP		EQUALS	PHSPRDT3
 BASETEMP	EQUALS	TBASE4

--- a/Comanche055/IMU_CALIBRATION_AND_ALIGNMENT.agc
+++ b/Comanche055/IMU_CALIBRATION_AND_ALIGNMENT.agc
@@ -19,7 +19,9 @@
 ##				and fixed the errors found.
 ##		2017-01-14 RSB	Fixed comment-text errors located while 
 ##				diff'ing with Colossus 249.
-
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
+##
 ## The contents of the "Comanche055" files, in general, are transcribed 
 ## from scanned documents. 
 ##
@@ -1181,7 +1183,7 @@ TAR1		SLOAD*	SR2		# X1=2 X2=12 S2=6 X1=0 X2=6 S2=6
 		BANK	33
 		SETLOC	IMUCAL
 		BANK
-		COUNT*	$$/P03
+		COUNT*	$$/PO3
 		
 CONTIN33	CA	ONE
 		TS	STARCODE

--- a/Comanche055/INTERPRETER.agc
+++ b/Comanche055/INTERPRETER.agc
@@ -24,7 +24,9 @@
 ##				identified while proofing Artemis 072.
 ##		2017-03-15 RSB	Comment-text fixes identified in 5-way
 ##				side-by-side diff of Luminary 69/99/116/131/210.
-
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
+##
 ## This source code has been transcribed or otherwise adapted from digitized
 ## images of a hardcopy from the MIT Museum.  The digitization was performed
 ## by Paul Fjeld, and arranged for by Deborah Douglas of the Museum.  Many
@@ -369,7 +371,7 @@ MISCJUMP	TCF	AXT		# 00 - ADDRESS TO INDEX TRUE.
 
 ## Page 1118
 # THE FOLLOWING JUMP TABLE APPIES TO UNARY INSTRUCTIONS.
-		COUNT*	$$/INTER
+		COUNT   00/INTER
 		BANK	0		# 00 - EXIT - DETECTED EARLIER.
 UNAJUMP		TCF	SQRT		# 01 - SQUARE ROOT.
 		TCF	SINE		# 02 - SIN.

--- a/Comanche055/KALCMANU_STEERING.agc
+++ b/Comanche055/KALCMANU_STEERING.agc
@@ -12,6 +12,8 @@
 ##		2016-12-10 RSB	Proofed comments with octopus/ProoferComments
 ##				and fixed the errors found.
 ##		2017-01-28 RSB	WTIH -> WITH.
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
 ##
 ## The contents of the "Comanche055" files, in general, are transcribed 
 ## from scanned documents. 
@@ -249,7 +251,7 @@ STOPYZ		CAF	ZERO
 		BANK
 
 ## Page 419
-ZEROERROR	CA	CDUX		# PICK UP CDU ANGLES AND STORE IN
+ZEROEROR	CA	CDUX		# PICK UP CDU ANGLES AND STORE IN
 		TS	CDUXD		# CDU DESIRED
 		CA	CDUY
 		TS	CDUYD

--- a/Comanche055/MEASUREMENT_INCORPORATION.agc
+++ b/Comanche055/MEASUREMENT_INCORPORATION.agc
@@ -15,6 +15,8 @@
 ##				and corrected the errors found.
 ##		2017-01-15 RSB	Fixed comment-text errors identified in 
 ##				diff'ing against Colossus 249.
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
 ##
 ## This source code has been transcribed or otherwise adapted from digitized
 ## images of a hardcopy from the MIT Museum.  The digitization was performed
@@ -438,7 +440,7 @@ DOCSM1		RTB	CALL
 			SVDWN1		# STORE DOWNLINK STATE VECTOR
 		GOTO
 			FAZAB4
-ZEROD		=	ZEROVECS
+ZEROO		=	ZEROVECS
 54DD		DEC	54
 6DD		DEC	-6
 12DD		DEC	12

--- a/Comanche055/P20-P25.agc
+++ b/Comanche055/P20-P25.agc
@@ -28,7 +28,9 @@
 ##				Artemis 72.
 ##		2017-03-17 RSB	Comment-text fixes identified by 4-way diff'ing
 ##				of Colossus 237 & 249, Comanche 55, and Artemis 72.
-
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
+##
 ## This source code has been transcribed or otherwise adapted from digitized
 ## images of a hardcopy from the MIT Museum.  The digitization was performed
 ## by Paul Fjeld, and arranged for by Deborah Douglas of the Museum.  Many
@@ -1518,7 +1520,7 @@ INITB		STORE	W +90D,1	# CLEAR 54 - 89
 		BANK
 		
 		EBANK=	CDUXD
-		COUNT*	$/CRS61
+		COUNT*	$$/CRS61
 		
 CRS61.1		STQ	SETPD
 			Q611

--- a/Comanche055/REENTRY_CONTROL.agc
+++ b/Comanche055/REENTRY_CONTROL.agc
@@ -17,6 +17,7 @@
 ##				and corrected the errors found.
 ##		2017-01-18 RSB	Fixed comment-text errors noted while diff'ing
 ##				vs Colossus 249.
+##              2021-04-04 ABS  Added empty page marker for page 882
 ##
 ## This source code has been transcribed or otherwise adapted from digitized
 ## images of a hardcopy from the MIT Museum.  The digitization was performed
@@ -1614,4 +1615,7 @@ COS15		2DEC	.965
 
 LATSLOPE	EQUALS	1/12TH
 # ... END OF RE-ENTRY CONSTANTS ...
+
+## Page 882
+## Empty page.
 

--- a/Comanche055/SXTMARK.agc
+++ b/Comanche055/SXTMARK.agc
@@ -15,6 +15,8 @@
 ##				and fixed the errors found.
 ##		2017-01-18 RSB	Fixed comment-text errors noted while diff'ing
 ##				vs Colossus 249.
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
 ##
 ## The contents of the "Comanche055" files, in general, are transcribed 
 ## from scanned documents. 
@@ -621,7 +623,7 @@ MARKIT		CCS	CDUCHKWD
 		SETLOC	SXTMARK1
 		BANK
 		
-		COUNT	20/SXTMK
+		COUNT	10/SXTMK
 		
 # PROGRAM NAME - MARKDIF			DATE- 19 SEPT 1967
 #

--- a/Comanche055/T4RUPT_PROGRAM.agc
+++ b/Comanche055/T4RUPT_PROGRAM.agc
@@ -21,6 +21,8 @@
 ##		2017-02-08 RSB	Comment-text fixes identified while proofing Artemis 72.
 ##		2017-03-03 RSB	Fixed comment-text errors identified while proofing
 ##				Luminary 116.
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
 ##
 ## The contents of the "Comanche055" files, in general, are transcribed
 ## from scanned documents.
@@ -1332,7 +1334,7 @@ OPTDRIVE	CA	CDUS			# GRAB OPTIC SHAFT CDU
 		TCF	OZONE	+1
 OZONE		CAF	ZERO			# ABS(CDUS) LESS THEN 90 DEG-ZONE ZERO
 		TS	ZONE
-		COUNT*	$$/T4RUPT
+		COUNT*	$$/T4RPT
 CONTDRVE	CCS	OPTIND
 		TC	+4			# WORK COARS OPTICS
 		TC	+3			# WORK COARS OPTICS

--- a/Luminary099/INTERPRETER.agc
+++ b/Luminary099/INTERPRETER.agc
@@ -21,7 +21,9 @@
 ##		2017-03-13 RSB	Comment-text fixes noted in proofing Luminary 116.
 ##		2017-03-15 RSB	Comment-text fixes identified in 5-way
 ##				side-by-side diff of Luminary 69/99/116/131/210.
-
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
+##
 ## This source code has been transcribed or otherwise adapted from
 ## digitized images of a hardcopy from the MIT Museum.  The digitization
 ## was performed by Paul Fjeld, and arranged for by Deborah Douglas of
@@ -416,7 +418,7 @@ DOSTORE		TS	ADDRWD
 		MASK	B12T14
 		EXTEND
 		MP	BIT5		# EACH TRANSFER VECTOR ENTRY IS TWO WORDS.
-		INDEX	A
+ITR0		INDEX	A
 		TCF	STORJUMP
 		
 ## Page 1015

--- a/Luminary099/Main.annotation
+++ b/Luminary099/Main.annotation
@@ -19,7 +19,7 @@ Notations on the program listing read, in part:<br>
 <br>
 <pre>
 	GAP:  ASSEMBLE REVISION 001 OF AGC PROGRAM LMY99 BY NASA 2021112-061
-	20'35 OCT. 28,1968
+	16:27 JULY 14,1969
 </pre>
 Note that the date is the date of the printout, not the date of the program revision.
 </td></tr></tbody></table>

--- a/Luminary099/POWERED_FLIGHT_SUBROUTINES.agc
+++ b/Luminary099/POWERED_FLIGHT_SUBROUTINES.agc
@@ -18,7 +18,9 @@
 ##				side-by-side diff of Luminary 69/99/116/131/210.
 ##		2017-03-17 RSB	Comment-text fixes identified in diff'ing
 ##				Luminary 99 vs Comanche 55.
-
+##              2021-04-04 ABS  Fixed minor symbol name transcription errors as
+##                              verified by sort order in end-of-listing tables.
+##
 ## This source code has been transcribed or otherwise adapted from
 ## digitized images of a hardcopy from the MIT Museum.  The digitization
 ## was performed by Paul Fjeld, and arranged for by Deborah Douglas of
@@ -254,7 +256,7 @@ R*TL**P		CCS	DEXDEX		#       	+3 --> 0	-3 --> 2
 LOOP2		DXCH	BUF		# LOADING VECTOR COMPONENT, STORING INDEX
 ## Page 1264
 LOOP1		DXCH	MPAC
-		CA	SINSLOC
+		CA	SINESLOC
 		AD	DEX1
 		TS	ADDRWD
 
@@ -296,7 +298,7 @@ TSTPOINT	CCS	DEXDEX		# ONLY THE BRANCHING FUNCTION IS USED
 		TCF	R*TL**P
 		TC	RTNSAVER
 
-SINSLOC		ADRES	SINCDU		# FOR USE IN SETTING ADDRWD
+SINESLOC	ADRES	SINCDU		# FOR USE IN SETTING ADDRWD
 
 INDEXI		DEC	4		# **********   DON'T   **********
 		DEC	2		# **********   TOUCH   **********


### PR DESCRIPTION
I've written an AGC assembler to learn a little more about the computer. It's based solely on my reading of the original MIT/IL documentation that you've collected, but of course takes your yaYUL-formatted source files as input. 

I've run it on at Luminary099 and Comanche055 so far. It generates complete and correct binary output for those and, for fun, it also outputs end-of-listing information that mimics the GAP output on the original scans. I've spot-checked those listings, which mostly involves comparing entries between my output and the scans, or the first and last entry on each page for large tables, or the first and last entry on every Nth page for very large tables. Then I've fixed any discrepancies that appear, which is the source of this PR.

There are 10 location symbol adjustments, 5 COUNT name changes, and 2 miscellaneous changes.

The symbol differences are mostly minor transcription errors in symbol names, causing them to appear out of order in the EBCDIC-sorted informational tables. I've verified the proper symbol names by the symbol's location in the original tables, and by staring closely at the scans for those cases where the sort problem is a result of a character change to one with a similar glyph (ZEROD to ZEROO or P00DAPAD to POODAPAD for example.) I've also added a couple of unreferenced symbols that were omitted from the transcriptions.

The COUNT operand changes are mostly typos or transcription errors similar to the ones above. There is one interesting one in Comanche055/IMU_CALIBRATION_AND_ALIGNMENT.agc that appears to be a typo in the original code that was "corrected" in transcription - "$$/P03" with a zero appears in several places elsewhere in the original, but here it should be "$$/PO3" with the letter O.

I also added a empty page comment for page 882 in Comanche055, and fixed the printout date in Luminary099/Main.annotation.

These don't have any effect on the binary output, of course, and I've verified that with a yaYUL run as well to ensure I didn't accidently break anything. And it's not an exhaustive check of all symbol names. But I think it's nice to have for consistency and the changes here help my assembler reproduce some of the original GAP output.