### PR TITLE
Add WebAssembly compilation target for yaAGC

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ On Fedora 22 or later you may encounter that the wxWidgets doesn't have the wx-c
 * You will need SUNWgnome-common-devel, SUNWGtk, SUNWxorg-headers, FSWxorg-headers, SUNWncurses, SUNWtcl, SUNWtk and SUNWlibsdl
 * You will also need GNU readline 6.0, wxWidgets 2.8.9 (with `configure --disable-shared`), Allegro 4.2.2 (with "configure --enable-shared=no --enable-static=yes") and to put `/usr/local/bin` and/or `/usr/local/bin/wx-config` linked into your `PATH`.
 
+## WebAssembly
+
+* Requires `clang` from the LLVM project, plus a C standard library which compiles down to WASI system calls. Clang can directly emit WebAssembly since version 8.  [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) provides a WebAssembly toolchain (clang plus C/C++ standard libraries).  A build from the source of [wasi-sdk revision a927856 ("use llvm 12.0.0 release")](https://github.com/WebAssembly/wasi-sdk/tree/a927856376271224d30c5d7732c00a0b359eaa45) has been tested with the Virtual AGC components listed in the section "WebAssembly" below, but the project also [supplies pre-built packages](https://github.com/WebAssembly/wasi-sdk/releases) for various platforms which should work just as well. In the build scripts of Virtual AGC, it is assumed that `wasi-sdk` is installed at `/opt/wasi-sdk`, but you can customize this path (see section "WebAssembly" below).
+* Requires `wasm-opt` (from the `binaryen` package) for WebAssembly code optimization.
+* Requires `wasm-strip` (from the `wabt` package) to minimize the size of the WebAssembly code.
+* Optionally, `wasm2wat` (from the `wabt` package) to translate binary code to human-readable text representation.
+
 
 More information at http://www.ibiblio.org/apollo/download.html#Build
 
@@ -254,6 +261,37 @@ To match the default setup of the installer program execute the following:
 You can make a desktop icon called *Virtual AGC* that links to `/VirtualAGC/bin/VirtualAGC`. The image normally used for the desktop icon is found at `/VirtualAGC/bin/ApolloPatch2.png`.
 
 Unfortunately the ACA simulation (joystick) programs do not work in this environment.
+
+
+## WebAssembly
+
+In the Virtual AGC build scripts, it is assumed that `wasi-sdk` is installed
+at `/opt/wasi-sdk`. You can customize the path by setting
+`WASI_SDK_PATH=/path/to/wasi-sdk` on the command line when executing `make`.
+
+For all builds to WebAssembly, put `WASI=yes` before `make`.
+
+Currently, only the following Virtual AGC components can be compiled for the
+WebAssembly target:
+
+### yaAGC
+
+If you have any leftover build artifacts in the `yaAGC` directory, run
+`make clean` in it.
+
+To build, simply `cd` into the root directory and do:
+
+`WASI=yes make yaAGC`
+
+This will produce `yaAGC.wasm` (about 100 kB).
+
+To additionally get a text representation, go into the `yaAGC` directory and
+run:
+
+`make yaAGC.wast`
+
+This will produce `yaAGC.wast` (about 900 kB).
+
 
 # Endnotes
 

--- a/yaAGC/Makefile
+++ b/yaAGC/Makefile
@@ -76,6 +76,7 @@
 #				else's builds.
 #		2016-11-12 RSB	"Permanently" disabled READLINE.
 #		2016-11-18 RSB	Explicitly include socket library in Solaris.
+#		2021-05-13 MKF	Defined WASI and targets yaAGC.wasm, yaAGC.wast.
 
 LIBS=${LIBS2}
 
@@ -84,7 +85,11 @@ PREFIX=/usr/local
 endif
 
 .PHONY: default
+ifdef WASI
+default: yaAGC.wasm
+else
 default: yaAGC
+endif
 
 #---------------------------------------------------------------------------
 # The use of libreadline adds a command-history to yaAGC, but may have some
@@ -124,6 +129,30 @@ endif # MACOSX
 endif # NOREADLINE
 
 CFLAGS2 += -DGDBMI
+
+ifdef WASI
+WASI_SDK_PATH ?= /opt/wasi-sdk
+
+CFLAGS2 = \
+	--target=wasm32-wasi \
+	--sysroot ${WASI_SDK_PATH}/share/wasi-sysroot \
+	-DWASI=yes \
+	-O3 \
+	-flto \
+	-fwhole-program-vtables \
+	-fvirtual-function-elimination
+
+LDFLAGS2 = \
+	--no-entry \
+	--export-dynamic \
+	--unresolved-symbols=import-functions \
+	-L ${WASI_SDK_PATH}/share/wasi-sysroot/lib/wasm32-wasi \
+	-lc \
+	--export=malloc \
+	--export=free \
+	--import-memory \
+	--lto-O3
+endif
 
 # Alberto Galdo's iPhone mod.
 ifdef IPHONE
@@ -183,6 +212,14 @@ yaAGC:	$(OBJECTS) checkdec.o libyaAGC.a ${NATIVE_WINAGC}
 	${cc} ${CFLAGS} ${CFLAGS2_NATIVE} -o yaAGC ${OBJECTS} checkdec.o \
 	libyaAGC.a -L. ${STATIC} ${LIBS} -lpthread -lyaAGC -lm ${CURSES}
 
+yaAGC.wasm: wasm.o agc_engine.o agc_engine_init.o agc_utilities.o ringbuffer_api.o ringbuffer.o
+	${WASI_SDK_PATH}/bin/wasm-ld ${LDFLAGS2} -o $@ $^
+	wasm-opt $@ -Oz -o $@
+	wasm-strip $@
+
+yaAGC.wast: yaAGC.wasm
+	wasm2wat $< > $@
+
 libyaAGC.a: ${LIBOBJECTS}
 ifdef IPHONE
 	${IPHONE_DEV}/usr/bin/ar -rc $@ $^
@@ -195,7 +232,7 @@ endif
 	touch ../yaDEDA/src/main.c
 
 clean:
-	rm -f yaAGC libyaAGC.a *.o *~ *.bak *.elf *.o68 *.o8 *.rel *.exe *-macosx
+	rm -f yaAGC libyaAGC.a *.o *~ *.bak *.elf *.o68 *.o8 *.rel *.exe *-macosx *.wasm *.wast
 
 install:	yaAGC
 	cp yaAGC ${PREFIX}/bin
@@ -205,13 +242,17 @@ checkdec.o: ../Tools/checkdec.c
 	${cc} ${CFLAGS} ${CFLAGS2} -O0 -DNVER=${NVER} -DINSTALLDIR="\"${PREFIX}/bin\"" -c -o $@ $<
 
 %.o:	%.c agc_engine.h
+ifdef WASI
+	${WASI_SDK_PATH}/bin/clang ${CFLAGS2} -c -o $@ $<
+else
 	${cc} ${CFLAGS0} ${CFLAGS2} -DNVER=${NVER} -DINSTALLDIR="\"${PREFIX}/bin\"" -c -o $@ $<
+endif
 
 #----------------------------------------------------------------------------------
 # Building for multiple architectures, using IMCROSS. 
 
 .PHONY: all-archs
-all-archs: default yaAGC.exe WinAGC.exe yaAGC-macosx
+all-archs: default yaAGC.exe WinAGC.exe yaAGC-macosx yaAGC.wasm
 
 #CSOURCE:=main.c agc_engine_init.c agc_engine.c agc_utilities.c rfopen.c \
 #	 Backtrace.c SocketAPI.c DecodeDigitalDownlink.c ../Tools/checkdec.c \

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -91,6 +91,8 @@
  * 		05/16/17 MAS    Enabled interrupts at startup.
  * 		05/31/17 RSB	Added --initialize-sunburst-37.
  * 		07/13/17 MAS	Added initialization of the three HANDRUPT traps.
+ * 		05/13/21 MKF	Disabled UnblockSocket for the WASI target
+ *  				(there are no sockets in wasi-libc)
  */
 
 // For Orbiter.
@@ -232,7 +234,7 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   int RetVal = 0, i, j, Bank;
   FILE *cd = NULL;
 
-#ifndef WIN32
+#if !defined (WIN32) && !defined(WASI)
   // The purpose of this is to make sure that getchar doesn't halt the program
   // when there's no keystroke immediately available.
   UnblockSocket (fileno (stdin));

--- a/yaAGC/agc_utilities.c
+++ b/yaAGC/agc_utilities.c
@@ -53,13 +53,20 @@
 		                (namely, that yaAGC no longer listened on the
 		                specified port on 64-bit Linux Mint and Ubuntu)
 		                has actually been fixed in the makefile.
+		05/13/21 MKF    Defined WASI. netdb.h is not implemented in
+		                wasi-libc, and so, socket-related code has to
+		                be disabled in WASI.
 */
 
 // ... and the project's includes.
 #include <stdio.h>
 #include <string.h>
 #ifndef WIN32
+
+#ifndef WASI
 #include <netdb.h>
+#endif
+
 #include <netinet/in.h>
 #include <sys/socket.h>
 #endif
@@ -159,6 +166,7 @@ ParseIoPacketAGS (unsigned char *Packet, int *Type, int *Data)
   return (0);
 }
 
+#ifndef WASI
 /////////////////////////////////////////////////////////////////////////////////
 // Portable functions (*NIX and Win32) for working with sockets.  
 
@@ -390,3 +398,4 @@ CallSocket (char *hostname, unsigned short portnum)
   UnblockSocket (s);
   return (s);
 }
+#endif // #ifndef WASI

--- a/yaAGC/ringbuffer.c
+++ b/yaAGC/ringbuffer.c
@@ -1,0 +1,68 @@
+/*
+  ringbuffer - Implements a simple FIFO ringbuffer.
+  Copyright 2020 Michael Karl Franzl <public.michael@franzl.name>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Filename:  ringbuffer.c
+  Purpose:   Implements a simple FIFO ringbuffer.
+  Contact:   Michael Karl Franzl <public.michael@franzl.name>
+  Mods:      2020-06-07 MKF  Created.
+*/
+
+#include "ringbuffer.h"
+
+#include <string.h>
+
+/*
+ * Initialize the ringbuffer; make it empty.
+ */
+void ringbuffer_init (ringbuffer* buf)
+{
+  buf->tail = buf->head = 0;
+}
+
+/* Copies `element` into the ringbuffer. Returns the number of copied bytes.
+ * If the ringbuffer is full, does nothing and returns 0.
+ */
+int ringbuffer_put (ringbuffer* buf,
+                       unsigned char element[RINGBUFFER_ELEMENT_SIZE])
+{
+  int i = (buf->head + RINGBUFFER_ELEMENT_SIZE) & (RINGBUFFER_CAPACITY - 1);
+  if (i == buf->tail)
+    return 0; // full
+
+  memcpy (buf->data + buf->head, element, RINGBUFFER_ELEMENT_SIZE);
+  buf->head = i;
+
+  return RINGBUFFER_ELEMENT_SIZE;
+}
+
+
+/* Copies the next entry from `buf` into `element` and returns the number
+ * of copied bytes.
+ * If the ringbuffer is empty, does nothing and returns 0.
+ */
+int ringbuffer_get(ringbuffer* buf,
+                      unsigned char element[RINGBUFFER_ELEMENT_SIZE])
+{
+  if (buf->tail == buf->head)
+    return 0; // empty
+
+  memcpy (element, buf->data + buf->tail, RINGBUFFER_ELEMENT_SIZE);
+  buf->tail = (buf->tail + RINGBUFFER_ELEMENT_SIZE) & (RINGBUFFER_CAPACITY - 1);
+
+  return RINGBUFFER_ELEMENT_SIZE;
+}

--- a/yaAGC/ringbuffer.h
+++ b/yaAGC/ringbuffer.h
@@ -1,0 +1,40 @@
+/*
+  ringbuffer - Implements a simple FIFO ringbuffer.
+  Copyright 2020 Michael Karl Franzl <public.michael@franzl.name>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Filename:  ringbuffer.h
+  Purpose:   Implements a simple FIFO ringbuffer.
+  Contact:   Michael Karl Franzl <public.michael@franzl.name>
+  Mods:      2020-06-07 MKF  Created.
+*/
+
+#define RINGBUFFER_ELEMENT_SIZE 4
+#define RINGBUFFER_ELEMENTS 1024
+#define RINGBUFFER_CAPACITY RINGBUFFER_ELEMENTS * RINGBUFFER_ELEMENT_SIZE
+
+typedef struct {
+  unsigned char data[RINGBUFFER_CAPACITY];
+  int tail;
+  int head;
+} ringbuffer;
+
+extern ringbuffer ringbuffer_in;
+extern ringbuffer ringbuffer_out;
+
+void ringbuffer_init (ringbuffer *buf);
+int ringbuffer_put (ringbuffer* buf, unsigned char* Packet);
+int ringbuffer_get (ringbuffer* buf, unsigned char* Packet);

--- a/yaAGC/ringbuffer_api.c
+++ b/yaAGC/ringbuffer_api.c
@@ -1,0 +1,188 @@
+/*
+  Copyright 2020 Michael Karl Franzl <public.michael@franzl.name>
+
+  This file is part of yaAGC.
+
+  yaAGC is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  yaAGC is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with yaAGC; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  In addition, as a special exception, Ronald S. Burkey gives permission to
+  link the code of this program with the Orbiter SDK library (or with
+  modified versions of the Orbiter SDK library that use the same license as
+  the Orbiter SDK library), and distribute linked combinations including
+  the two. You must obey the GNU General Public License in all respects for
+  all of the code used other than the Orbiter SDK library. If you modify
+  this file, you may extend this exception to your version of the file,
+  but you are not obligated to do so. If you do not wish to do so, delete
+  this exception statement from your version.
+
+  Filename:  ringbuffer_api.c
+  Purpose:   Allows yaAGC to read/write i/o packets from/to simple ringbuffers
+             in memory.  This file was based on NullAPI.c. Some code was copied
+             from SocketAPI.c (where noted).
+             Ring buffers were chosen so as to not slow down the AGC execution
+             from possibly slow foreign function calls. The ringbuffers
+             obviously have to be filled and emptied from other places where
+             exact timing is not so relevant.
+  Contact:   Michael Karl Franzl <public.michael@franzl.name>
+  Reference: http://www.ibiblio.org/apollo/index.html
+  Mods:      2020-06-07 MKF  Created.
+*/
+
+#include "yaAGC.h"
+#include "agc_engine.h"
+#include "ringbuffer.h"
+
+static int CurrentChannelValues[256] = { 0 };
+static int ChannelMasks[256] = { 077777 };
+
+static int ChannelIsSetUp = 0;
+
+static void
+ChannelSetup (agc_t* State)
+{
+  ChannelIsSetUp = 1;
+
+  ringbuffer_init (&ringbuffer_out);
+  ringbuffer_init (&ringbuffer_in);
+
+  for (int i = 0; i < 256; i++)
+    ChannelMasks[i] = 077777;
+}
+
+/* The simulated AGC CPU calls this function when it wants to output data.  It
+ * stores the data in ringbuffer_out so as to not have to call
+ * a foreign and possibly slow function.  The data is supposed to be read from
+ * the ring buffer asynchronously. See also NullAPI.c
+ *
+ * The bulk of the code was copied from SocketAPI.c
+ */
+void
+ChannelOutput (agc_t* State, int Channel, int Value)
+{
+  if (!ChannelIsSetUp)
+    ChannelSetup (State);
+
+  // Some output channels have purposes within the CPU, so we have to
+  // account for those separately.
+  if (Channel == 7)
+    {
+      State->InputChannel[7] = State->OutputChannel7 = (Value & 0160);
+      return;
+    }
+
+  // Stick data into the RHCCTR registers, if bits 8,9 of channel 013 are set.
+  if (Channel == 013 && 0600 == (0600 & Value) && !CmOrLm)
+    {
+      State->Erasable[0][042] = LastRhcPitch;
+      State->Erasable[0][043] = LastRhcYaw;
+      State->Erasable[0][044] = LastRhcRoll;
+    }
+
+  unsigned char Packet[4];
+  if (!FormIoPacket (Channel, Value, Packet))
+    ringbuffer_put (&ringbuffer_out, Packet);
+}
+
+
+/* The simulated AGC CPU calls this function when it wants to input data.
+ * The data is read from the ring buffer ringbuffer_in.
+ * See also NullAPI.c
+ */
+int
+ChannelInput (agc_t* State)
+{
+  if (!ChannelIsSetUp)
+    ChannelSetup (State);
+
+  unsigned char Packet[4];
+  while (ringbuffer_get(&ringbuffer_in, Packet))
+    {
+      // This body of the while loop follows the work done in SocketAPI.c.
+      // I removed socket client related code, and refactored and reformatted
+      // the code.
+
+      int uBit, Value, Channel;
+
+      if (ParseIoPacket (Packet, &Channel, &Value, &uBit))
+        continue; // Not a valid packet; try the next one.
+
+      Value &= 077777; // Convert to AGC format (only keep upper 15 bits).
+
+      if (uBit)
+        {
+          // This is not an actual input to the CPU. It only sets a bit mask
+          // for masking of future inputs.
+          ChannelMasks[Channel] = Value;
+          continue; // Proceed with the next packet in the ring buffer.
+        }
+
+      if (Channel & 0x80)
+        {
+          // This is a counter increment. According to NullAPI.c we need to
+          // immediately return a value of 1.
+          UnprogrammedIncrement (State, Channel, Value);
+          return 1;
+        }
+
+      // Mask out irrelevant bits, set current bits, and write to CPU.
+      Value &= ChannelMasks[Channel];
+      Value |= ReadIO (State, Channel) & ~ChannelMasks[Channel];
+      WriteIO (State, Channel, Value);
+
+      // If this is a keystroke from the DSKY, generate an interrupt req.
+      if (Channel == 015)
+        State->InterruptRequests[5] = 1;
+      // If this is on fictitious input channel 0173, then the data
+      // should be placed in the INLINK counter register, and an
+      // UPRUPT interrupt request should be set.
+      else if (Channel == 0173)
+        {
+          State->Erasable[0][RegINLINK] = (Value & 077777);
+          State->InterruptRequests[7] = 1;
+        }
+      // Fictitious registers for rotational hand controller (RHC).
+      // Note that the RHC angles are not immediately used, but
+      // merely squirreled away for later.  They won't actually
+      // go into the counter registers until the RHC counters are
+      // enabled and the data requested (bits 8,9 of channel 13).
+      else if (Channel == 0166)
+        {
+          LastRhcPitch = Value;
+          ChannelOutput (State, Channel, Value);  // echo
+        }
+      else if (Channel == 0167)
+        {
+          LastRhcYaw = Value;
+          ChannelOutput (State, Channel, Value);  // echo
+        }
+      else if (Channel == 0170)
+        {
+          LastRhcRoll = Value;
+          ChannelOutput (State, Channel, Value);  // echo
+        }
+    } // while
+
+  return 0;
+}
+
+void
+ChannelRoutine (agc_t* State)
+{
+}
+
+void
+ShiftToDeda (agc_t* State, int Data)
+{
+}

--- a/yaAGC/wasm.c
+++ b/yaAGC/wasm.c
@@ -1,0 +1,187 @@
+/*
+  Copyright 2020 Michael Karl Franzl <public.michael@franzl.name>
+
+  This file is part of yaAGC.
+
+  yaAGC is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  yaAGC is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with yaAGC; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  In addition, as a special exception, Ronald S. Burkey gives permission to
+  link the code of this program with the Orbiter SDK library (or with
+  modified versions of the Orbiter SDK library that use the same license as
+  the Orbiter SDK library), and distribute linked combinations including
+  the two. You must obey the GNU General Public License in all respects for
+  all of the code used other than the Orbiter SDK library. If you modify
+  this file, you may extend this exception to your version of the file,
+  but you are not obligated to do so. If you do not wish to do so, delete
+  this exception statement from your version.
+
+  Filename:  wasm.c
+  Purpose:   Entrypoints for WebAssembly
+  Contact:   Michael Karl Franzl <public.michael@franzl.name>
+  Reference: http://www.ibiblio.org/apollo/index.html
+  Mods:      2020-06-07 MKF.  Created.
+*/
+
+#include "yaAGC.h"
+#include "agc_engine.h"
+#include "ringbuffer.h"
+
+#define export __attribute__((visibility("default")))
+
+agc_t State;
+
+ringbuffer ringbuffer_in;
+ringbuffer ringbuffer_out;
+
+/* Returns a pointer to the erasable memory of the AGC.
+ * This should be used only for the inspection of the memory.
+ */
+export uint32_t
+get_erasable_ptr ()
+{
+  return (uint64_t)&State.Erasable;
+}
+
+
+/* Copies rom_data to the fixed memory of the AGC.
+ * This function is based on `main()` in EmbeddedDemo.c.
+ */
+export void
+set_fixed (unsigned char* rom_data)
+{
+  unsigned int i = 0;
+  unsigned int j = 0;
+
+  for (unsigned int bank = 2; bank <= 35;)
+    {
+      unsigned int index = 2 * (i * 02000 + j);
+      State.Fixed[bank][j++] =
+        (rom_data[index] * 256 + rom_data[index + 1]) >> 1;
+
+      if (j == 02000)
+        {
+          i++;
+          j = 0;
+          // bank filled.  Advance to next fixed-memory bank.
+          if (bank == 2)
+            bank = 3;
+          else if (bank == 3)
+            bank = 0;
+          else if (bank == 0)
+            bank = 1;
+          else if (bank == 1)
+            bank = 4;
+          else
+            bank++;
+        }
+    }
+}
+
+
+/* Resets the CPU. */
+export void
+cpu_reset ()
+{
+  agc_engine_init (&State, NULL, NULL, 0);
+}
+
+
+/*
+ * Steps the CPU a number of (`steps`) times.
+ * Call this function so that the CPU is stepped once every 11.72 microseconds.
+ */
+export void
+cpu_step (uint32_t steps)
+{
+  for (uint32_t i = 0; i < steps; i++)
+    agc_engine (&State);
+}
+
+
+/*
+ * Compose a 4 byte "Packet for Socket Implementation of AGC I/O System" from a
+ * given channel number and data, and put it into a ringbuffer for later
+ * processing by yaAGC.
+ *
+ * `data` is 15 bits.
+ *
+ * `channel` is 9 bits, composed of:
+ *
+ * - Bit 0-6:  Port number `p`.
+ * - Bit 7:    Type bit `t`. If set, this packet is an "unprogrammed counter
+ *             increment".  If unset, this packet will write `data` to the
+ *             port.
+ * - Bit 8:    Mask bit `u`. If set, the data is set as a bit mask for the
+ *             given port number.  Does not influence the state of the CPU.
+ *
+ * See https://www.ibiblio.org/apollo/developer.html
+ *
+ * You can call this function up to RINGBUFFER_ELEMENTS times at once before
+ * the ring buffer is full. Some or all of the packets in the buffer will be
+ * processed at the next call to `cpu_step`.
+ *
+ * Returns 0 when then ringbuffer was full and no write took place. You then
+ * need to re-try later.
+ *
+ * Returns a positive number if the write was successful.
+ *
+ * Returns a negative number if a packed could not be formed.
+ */
+export int
+packet_write (uint16_t channel, uint16_t data)
+{
+  unsigned char packet[4];
+
+  if (FormIoPacket (channel, data, packet))
+    return -1;
+
+  return ringbuffer_put (&ringbuffer_in, packet);
+}
+
+
+/*
+ * Returns from a ringbuffer the next output from yaAGC.
+ *
+ * The return value is a single integer number which is the combination of the
+ * port number and the data.
+ *
+ * - Bits  0-14: 15 bit data
+ * - Bits 15-21: 7 bit port number
+ *
+ * If 0 is returned, the ringbuffer was emtpy, and the value can be discarded.
+ * To keep the ringbuffer depleted, call this function and process the return
+ * values repeatedly until 0 is returned.
+ *
+ * If you want the timing to be perfect, you need to call this function every
+ * time after calling `cpu_step()`.
+ */
+export uint32_t
+packet_read ()
+{
+  unsigned char packet[4];
+  int port, val, bit;
+
+  if (ringbuffer_get (&ringbuffer_out, packet))
+    {
+      ParseIoPacket (packet, &port, &val, &bit);
+      return (port << 16) + val;
+    }
+  return 0;
+}
+
+void
+BacktraceAdd (agc_t* State, int Cause)
+{
+}

--- a/yaAGC/yaAGC.h
+++ b/yaAGC/yaAGC.h
@@ -45,6 +45,9 @@
 		08/13/05 RSB	Added the extern "C" stuff.
 		02/28/09 RSB	Added FORMAT_64U, FORMAT_64O for bypassing
 				some compiler warnings on 64-bit machines.
+		05/13/21 MKF	Disabled headers which are not implemented
+				in wasi-libc. Disabled functions which cannot
+				be ported to wasi-libc.
 */
 
 #ifdef __cplusplus
@@ -59,15 +62,19 @@ extern "C" {
 #endif
 
 // Figure out the right include-files for socket stuff.
-#if defined(unix)
+#if defined(unix) || defined(WASI)
 
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <netdb.h>
 #include <netinet/in.h>
 #include <fcntl.h>
 #include <stdint.h>
+
+#ifndef WASI
+#include <netdb.h>
+#endif
+
 #ifdef __APPLE_CC__
 #define FORMAT_64U "%llu"
 #define FORMAT_64O "%llo"
@@ -96,6 +103,7 @@ extern "C" {
 #define FORMAT_64O "%llo"
 
 #elif defined(SDCC)
+#elif defined(WASI)
 
 #else
 
@@ -115,10 +123,12 @@ int ParseIoPacket (unsigned char *Packet, int *Channel, int *Value,
 int FormIoPacketAGS (int Type, int Data, unsigned char *Packet);
 int ParseIoPacketAGS (unsigned char *Packet, int *Type, int *Data);
 
+#ifndef WASI
 int InitializeSocketSystem (void);
 void UnblockSocket (int SocketNum);
 int EstablishSocket (unsigned short portnum, int MaxClients);
 int CallSocket (char *hostname, unsigned short portnum);
+#endif
 
 #endif // YAAGC_H
 


### PR DESCRIPTION
This pull request contains a minimal set of changes which adds a new compilation target for `yaAGC`: WebAssembly (Wasm). The resulting executable `yaAGC.wasm` is about 130 kB in size and is very portable. It will execute in all Wasm runtimes, which include, but are not limited to, internet browsers. This opens up the interesting possibility of distribution over the internet and client-side execution in most browsers, but also of embedding into a wide array of other contexts.

I also created a JavaScript wrapper (called `webAGC`) for the resulting executable `yaAGC.wasm` (see https://github.com/michaelfranzl/webAGC). The source code for a demonstration is also part of it (see https://github.com/michaelfranzl/webAGC/tree/dev/demo). A live version of the demo is hosted on my GitHub page https://michaelfranzl.github.io/webAGC/demo/ . (Please note that, to keep the JavaScript development workflow simpler, this demo currently requires a modern browser supporting "import maps", e.g. based on Chromium 89 or newer. But this is just a limitation of the demo itself, and not of any of the used components).

The `ChannelOutput` and `ChannelInput` functions were implemented to work with fast ringbuffers to eliminate the possibility of slow foreign function calls. Six functions were added as entry points into the WebAssembly context: to read from and write to mentioned ringbuffers, to set the fixed memory and read the erasable memory, and to reset and step the CPU. All code related to network sockets had to be disabled using pre-processor directives because there is no notion of networks in WASI/WebAssembly.

If the `printf`'s in the yaAGC source code were disabled, the executable would no longer depend on any WASI system calls (like `fd_*`), which would make it even more portable (and about 2 kB smaller).

My work was inspired by the project https://github.com/siravan/moonjs , but provides an independent implementation.