### PR TITLE
CMake: corrections, add more targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,10 @@ if(WIN32)
 endif()
 
 add_subdirectory(Tools)
+add_subdirectory(Luminary099)
 
 add_subdirectory(yaAGC)
+add_subdirectory(yaAGS)
 add_subdirectory(yaASM)
 add_subdirectory(yaDSKY2)
 add_subdirectory(yaLEMAP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
-cmake_minimum_required(VERSION 3.12)
-project(virtualAGC LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.14...3.21)
+project(virtualAGC
+LANGUAGES C CXX
+HOMEPAGE_URL "https://github.com/virtualagc/virtualagc")
 
-# this helps linters e.g. Visual Studio Intellicode work properly
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
-set(NVER \\\"2019-09-22\\\")
+set(NVER \\\"2020-12-24\\\")
+
+
+find_package(Threads)
 
 add_subdirectory(yaAGC)
 add_subdirectory(yaASM)
@@ -22,5 +26,5 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(HOME $ENV{HOME})
   endif()
 
-  set(CMAKE_INSTALL_PREFIX "${HOME}/VirtualAGC" CACHE PATH "..." FORCE)
+  set(CMAKE_INSTALL_PREFIX "${HOME}/VirtualAGC" CACHE PATH "install prefix" FORCE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(NVER \\\"2020-12-24\\\")
 find_package(Threads)
 
 if(WIN32)
-  set(WINSOCK_LIBRARIES wsock32)
+  set(WINSOCK_LIBRARIES wsock32 ws2_32 Iphlpapi winmm)
 endif()
 
 add_subdirectory(yaAGC)
@@ -21,7 +21,10 @@ add_subdirectory(yaASM)
 add_subdirectory(yaDSKY2)
 add_subdirectory(yaLEMAP)
 add_subdirectory(yaLVDC)
+add_subdirectory(yaOBC)
 add_subdirectory(yaYUL)
+
+add_subdirectory(enet)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(virtualAGC
 LANGUAGES C CXX
 HOMEPAGE_URL "https://github.com/virtualagc/virtualagc")
 
+include(CTest)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
 set(NVER \\\"2020-12-24\\\")
@@ -20,9 +22,6 @@ add_subdirectory(yaDSKY2)
 add_subdirectory(yaLEMAP)
 add_subdirectory(yaLVDC)
 add_subdirectory(yaYUL)
-
-## install to ~/VirtualAGC upon:
-# cmake --build build --target install
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Threads)
 add_subdirectory(yaAGC)
 add_subdirectory(yaASM)
 add_subdirectory(yaDSKY2)
+add_subdirectory(yaLEMAP)
 add_subdirectory(yaLVDC)
 add_subdirectory(yaYUL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ if(WIN32)
   set(WINSOCK_LIBRARIES wsock32 ws2_32 Iphlpapi winmm)
 endif()
 
+add_subdirectory(Tools)
+
 add_subdirectory(yaAGC)
 add_subdirectory(yaASM)
 add_subdirectory(yaDSKY2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ set(NVER \\\"2020-12-24\\\")
 
 find_package(Threads)
 
+if(WIN32)
+  set(WINSOCK_LIBRARIES wsock32)
+endif()
+
 add_subdirectory(yaAGC)
 add_subdirectory(yaASM)
 add_subdirectory(yaDSKY2)

--- a/Luminary099/CMakeLists.txt
+++ b/Luminary099/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_custom_target(MAIN.agc.bin
+COMMAND yaYUL --unpound-page MAIN.agc
+)

--- a/Luminary099/Makefile
+++ b/Luminary099/Makefile
@@ -19,6 +19,6 @@ include ../Makefile.inc
 AP11ROPE.bin: Luminary099.bin AP11ROPE.binsource
 	../Tools/oct2bin $(OCT2BIN_ARGS) <AP11ROPE.binsource
 	mv oct2bin.bin $@
-	# Uncomment and add to $(EXTRA_TARGETS) when this when AP11ROPE 
+	# Uncomment and add to $(EXTRA_TARGETS) when this when AP11ROPE
 	# proofing is complete
 	# diff -s $@ $<

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(listing2binsource listing2binsource.c utils.c)
+add_executable(oct2bin oct2bin.c utils.c)
+add_executable(checkdec checkdec.c)
+add_executable(bdiffhead bdiffhead.c)
+add_executable(webb2burkey-rope webb2burkey-rope.c)
+add_executable(split-interp split-interp.c)
+
+set(_targs listing2binsource oct2bin checkdec bdiffhead webb2burkey-rope split-interp)
+
+foreach(t ${_targs})
+  target_compile_definitions(${t} PRIVATE NVER="${NVER}" MAIN_PROGRAM)
+endforeach()
+
+install(TARGETS ${_targs})

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(listing2binsource listing2binsource.c utils.c)
 add_executable(oct2bin oct2bin.c utils.c)
+
 add_executable(checkdec checkdec.c)
+target_link_libraries(checkdec PRIVATE m)
+
 add_executable(bdiffhead bdiffhead.c)
 add_executable(webb2burkey-rope webb2burkey-rope.c)
 add_executable(split-interp split-interp.c)

--- a/enet/CMakeLists.txt
+++ b/enet/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(enet_src callbacks.c compress.c host.c list.c packet.c peer.c protocol.c unix.c win32.c)
+
+target_sources(yaOBC PRIVATE ${enet_src})
+target_sources(enetHost PRIVATE ${enet_src})

--- a/yaAGC/CMakeLists.txt
+++ b/yaAGC/CMakeLists.txt
@@ -14,9 +14,13 @@ if(Threads_FOUND)
   target_link_libraries(yaAGC PRIVATE Threads::Threads)
 endif()
 
+if(APPLE OR WIN32)
+  target_compile_definitions(yaAGC PRIVATE STDC_HEADERS)
+endif()
+
 if(WIN32)
   target_sources(yaAGC PRIVATE regex.c random.c)
-  target_link_libraries(yaAGC PRIVATE wsock32)
+  target_link_libraries(yaAGC PRIVATE ${WINSOCK_LIBRARIES})
 endif()
 
 install(TARGETS yaAGC)

--- a/yaAGC/CMakeLists.txt
+++ b/yaAGC/CMakeLists.txt
@@ -19,8 +19,9 @@ if(APPLE OR WIN32)
 endif()
 
 if(WIN32)
-  target_sources(yaAGC PRIVATE regex.c random.c)
-  target_link_libraries(yaAGC PRIVATE ${WINSOCK_LIBRARIES})
+  add_library(regex regex.c)
+  target_sources(yaAGC PRIVATE random.c)
+  target_link_libraries(yaAGC PRIVATE regex ${WINSOCK_LIBRARIES})
 endif()
 
 install(TARGETS yaAGC)

--- a/yaAGC/CMakeLists.txt
+++ b/yaAGC/CMakeLists.txt
@@ -5,20 +5,18 @@ set(_agc_src main.c agc_cli.c agc_simulator.c agc_debugger.c
 agc_gdbmi.c agc_disassembler.c agc_help.c nbfgets.c agc_symtab.c
 NormalizeSourceName.c ${CMAKE_CURRENT_SOURCE_DIR}/../Tools/checkdec.c Backtrace.c)
 
-find_package(Threads)
-
 add_library(libyaAGC ${_libagc_src})
 
 add_executable(yaAGC ${_agc_src})
 target_compile_definitions(yaAGC PRIVATE NVER="${NVER}" NOREADLINE="yes" GDBMI)
-target_link_libraries(yaAGC libyaAGC m)
+target_link_libraries(yaAGC PRIVATE libyaAGC m)
 if(Threads_FOUND)
-  target_link_libraries(yaAGC Threads::Threads)
+  target_link_libraries(yaAGC PRIVATE Threads::Threads)
 endif()
 
 if(WIN32)
   target_sources(yaAGC PRIVATE regex.c random.c)
-  target_link_libraries(yaAGC wsock32)
+  target_link_libraries(yaAGC PRIVATE wsock32)
 endif()
 
 install(TARGETS yaAGC)

--- a/yaAGS/CMakeLists.txt
+++ b/yaAGS/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(yaAGS mainAGS.c symbol_table.c nbfgets.c Backtrace.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC/NormalizeSourceName.c)
+target_link_libraries(yaAGS PRIVATE libyaAGS libyaAGC Threads::Threads m)
+target_include_directories(yaAGS PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC)
+target_compile_definitions(yaAGS PRIVATE NVER="${NVER}")
+if(WIN32)
+  target_link_libraries(yaAGS PRIVATE regex ${WINSOCK_LIBRARIES})
+endif(WIN32)
+if(APPLE OR WIN32)
+  target_compile_definitions(yaAGS PRIVATE STDC_HEADERS)
+endif()
+
+
+add_library(libyaAGS aea_engine_init.c aea_engine.c DebuggerHookAGS.c SocketAPI_AGS.c)
+target_include_directories(libyaAGS PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../yaAGC)

--- a/yaASM/CMakeLists.txt
+++ b/yaASM/CMakeLists.txt
@@ -3,7 +3,7 @@ project(virtualASM LANGUAGES C)
 enable_testing()
 
 add_executable(yaASM yaASM.c)
-target_link_libraries(yaASM m)
+target_link_libraries(yaASM PRIVATE m)
 
 add_test(NAME ASM:assemble COMMAND $<TARGET_FILE:yaASM> --input=${CMAKE_CURRENT_SOURCE_DIR}/Test.obc)
 

--- a/yaASM/CMakeLists.txt
+++ b/yaASM/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.12)
-project(virtualASM LANGUAGES C)
-enable_testing()
-
 add_executable(yaASM yaASM.c)
 target_link_libraries(yaASM PRIVATE m)
 

--- a/yaDSKY2/CMakeLists.txt
+++ b/yaDSKY2/CMakeLists.txt
@@ -1,3 +1,11 @@
+find_package(wxWidgets COMPONENTS gl core base)
+if(NOT wxWidgets_FOUND)
+  find_program(wxcfg NAMES wx-config)
+  if(NOT wxcfg)
+    return()
+  endif()
+endif()
+
 set(APPNAME yaDSKY2)
 
 set(SOURCES ${APPNAME}.cpp)
@@ -15,10 +23,9 @@ target_include_directories(${APPNAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../yaA
 target_compile_definitions(${APPNAME} PRIVATE NVER="${NVER}")
 
 if(WIN32)
-  target_link_libraries(${APPNAME} wsock32)
+  target_link_libraries(${APPNAME} PRIVATE wsock32)
 endif()
 
-find_package(wxWidgets COMPONENTS gl core base)
 if(wxWidgets_FOUND)
   target_include_directories(${APPNAME} PRIVATE ${wxWidgets_INCLUDE_DIRS})
   target_link_libraries(${APPNAME} PRIVATE ${wxWidgets_LIBRARIES})

--- a/yaDSKY2/CMakeLists.txt
+++ b/yaDSKY2/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(${APPNAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../yaA
 target_compile_definitions(${APPNAME} PRIVATE NVER="${NVER}")
 
 if(WIN32)
-  target_link_libraries(${APPNAME} PRIVATE wsock32)
+  target_link_libraries(${APPNAME} PRIVATE ${WINSOCK_LIBRARIES})
 endif()
 
 if(wxWidgets_FOUND)

--- a/yaLEMAP/CMakeLists.txt
+++ b/yaLEMAP/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(yaLEMAP yaLEMAP.c
+${CMAKE_CURRENT_SOURCE_DIR}/../yaYUL/SymbolTable.c ${CMAKE_CURRENT_SOURCE_DIR}/../yaYUL/strcmpEBCDIC.c)
+target_link_libraries(yaLEMAP PRIVATE m)
+
+add_executable(binLEMAP binLEMAP.c)
+
+install(TARGETS binLEMAP yaLEMAP)

--- a/yaLVDC/CMakeLists.txt
+++ b/yaLVDC/CMakeLists.txt
@@ -1,9 +1,14 @@
-cmake_minimum_required(VERSION 3.12)
-project(yaLVDC LANGUAGES C)
+include(CheckIncludeFile)
 
 set(SOURCE debug.c parseCommandLineArguments.c readAssemblies.c runOneInstruction.c yaLVDC.c
 gdbInterface.c processInterruptsAndIO.c readWriteCore.c virtualWire.c)
 
+check_include_file(time.h HAVE_TIME_H)
+
 add_executable(yaLVDC ${SOURCE})
+target_compile_definitions(yaLVDC PRIVATE HAVE_TIME_H=${HAVE_TIME_H})
+if(WIN32)
+  target_link_libraries(yaLVDC PRIVATE ${WINSOCK_LIBRARIES})
+endif(WIN32)
 
 install(TARGETS yaLVDC)

--- a/yaLVDC/virtualWire.c
+++ b/yaLVDC/virtualWire.c
@@ -26,7 +26,7 @@
  this file, you may extend this exception to your version of the file,
  but you are not obligated to do so. If you do not wish to do so, delete
  this exception statement from your version.
- 
+
  Filename:	virtualWire.c
  Purpose:	Portable functions (*NIX and Win32) for working with sockets
  for connecting yaLVDC to peripherals by "virtual wires".
@@ -56,7 +56,7 @@
 #include <winsock2.h>
 #endif
 
-#if (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__APPLE__) && defined(__MACH__)) || WIN32
 #define MSG_NOSIGNAL 0
 #endif
 
@@ -872,7 +872,7 @@ pendingVirtualWireActivity(void /* int id, int mask */)
 }
 
 /////////////////////////////////////////////////////////////////////////////////
-// Portable functions (*NIX and Win32) for working with sockets.  
+// Portable functions (*NIX and Win32) for working with sockets.
 
 // Used for socket-operation error codes.
 int virtualWireErrorCodes = 0;

--- a/yaLVDC/yaLVDC.c
+++ b/yaLVDC/yaLVDC.c
@@ -86,6 +86,10 @@ int cpuCurrentAccumulator = -1;
 
 #ifdef WIN32
 
+#if HAVE_TIME_H
+#include <time.h>
+#endif
+
 #include <windows.h>
 struct tms
   {

--- a/yaOBC/CMakeLists.txt
+++ b/yaOBC/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(yaOBC yaOBC.c)
+target_include_directories(yaOBC PRIVATE ${PROJECT_SOURCE_DIR}/enet/include)
+target_link_libraries(yaOBC PRIVATE m)
+
+add_executable(enetHost enetHost.c)
+target_include_directories(enetHost PRIVATE ${PROJECT_SOURCE_DIR}/enet/include)
+
+if(Threads_FOUND)
+  target_link_libraries(enetHost PRIVATE Threads::Threads)
+  target_link_libraries(yaOBC PRIVATE Threads::Threads)
+endif()
+
+if(WIN32)
+  target_link_libraries(enetHost PRIVATE ${WINSOCK_LIBRARIES})
+  target_link_libraries(yaOBC PRIVATE ${WINSOCK_LIBRARIES})
+endif(WIN32)
+
+install(TARGETS enetHost yaOBC)

--- a/yaYUL/CMakeLists.txt
+++ b/yaYUL/CMakeLists.txt
@@ -3,7 +3,7 @@ IncPc.c ParseBLOCK.c ParseERASE.c ParseInterpretiveOperand.c Pass.c yul2agc.c
 Parse2CADR.c ParseCADR.c ParseEqMinus.c ParseOCT.c PseudoToSegmented.c
 Parse2DEC.c ParseCHECKequals.c ParseEqualsECADR.c ParseSBANKEquals.c SymbolPass.c
 Parse2FCADR.c ParseEBANKEquals.c ParseGENADR.c ParseSETLOC.c SymbolTable.c
-ParseBANK.c ParseECADR.c ParseGeneral.c ParseST.c Utilities.c)
+ParseBANK.c ParseECADR.c ParseGeneral.c ParseST.c strcmpEBCDIC.c Utilities.c)
 
 add_compile_options(-Wall)
 

--- a/yaYUL/CMakeLists.txt
+++ b/yaYUL/CMakeLists.txt
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 3.12)
-project(virtualYUL LANGUAGES C)
-
 set(CFILES GetOctOrDec.c ParseBBCON.c ParseEQUALS.c ParseINDEX.c ParseXCADR.c yaYUL.c
 IncPc.c ParseBLOCK.c ParseERASE.c ParseInterpretiveOperand.c Pass.c yul2agc.c
 Parse2CADR.c ParseCADR.c ParseEqMinus.c ParseOCT.c PseudoToSegmented.c
@@ -13,7 +10,6 @@ add_compile_options(-Wall)
 # deferring cross-compile for now
 
 add_executable(yaYUL ${CFILES})
-target_compile_options(yaYUL PRIVATE ${CFLAGS})
 target_link_libraries(yaYUL PRIVATE m)
 target_compile_definitions(yaYUL PRIVATE NVER="${NVER}")
 


### PR DESCRIPTION
* skip yaDSKY2 if Wx not present
* handle time.h detection more correctly
* add yaLEMAP, yaOBC, yaAGS, Tools
* general project additions made since last CMake update
* add example target for Luminary099 using yaYUL

This was tested on GCC and Clang with MacOS, Windows, and Linux