### PR TITLE
Added --no-resume cli option

### DIFF
--- a/yaAGC/agc_cli.c
+++ b/yaAGC/agc_cli.c
@@ -102,6 +102,9 @@ static void CliShowUsage(void)
 "                         otherwise clean memory, in lieu of pad-loads.  Not\n"
 "                         required for subsequent runs.  Note that this option only\n"
 "                         has an effect if there is no existing core-dump file.\n"
+"--no-resume              Disables the resuming from a core-resume-file.\n"
+"                         By default yaAGC resumes from the \"core\" resume file or\n"
+"                         another file provided as a command line argument.\n"
 "Note that the exec-ropes file should contain exactly 36 banks\n"
 "(36x1024=36864 words, or 73728 bytes). Other sizes may be accepted,\n"
 "but it is unclear what (if any) utility such core-rope images\n"
@@ -192,6 +195,7 @@ static void CliInitializeOptions(void)
 	  Options.interlace = 50;
 	  Options.version = 0;
 	  Options.initializeSunburst37 = 0;
+	  Options.no_resume = 0;
 }
 /**
 This function takes a character string and checks the string for
@@ -244,6 +248,7 @@ static int CliProcessArgument(char* token)
 	else if (!strncmp (token, "-symtab=", 8)) Options.symtab = strdup(&token[8]);
 	else if (1 == sscanf (token,"-interlace=%d", &j)) Options.interlace = j;
 	else if (!strcmp (token, "-initialize-sunburst-37")) Options.initializeSunburst37 = 1;
+	else if (!strcmp (token, "-no-resume")) Options.no_resume = 1;
 	else if (Options.core == (char*)0) Options.core = strdup(token);
 	else if (Options.resume == (char*)0) Options.resume = strdup(token);
 	else result = CLI_E_UNKOWNTOKEN;

--- a/yaAGC/agc_cli.h
+++ b/yaAGC/agc_cli.h
@@ -68,6 +68,7 @@ typedef struct
   int	resumed;
   int	version;
   int	initializeSunburst37;
+  int	no_resume;
 } Options_t;
 
 extern Options_t* CliParseArguments(int argc, char *argv[]);

--- a/yaAGC/agc_simulator.c
+++ b/yaAGC/agc_simulator.c
@@ -63,9 +63,9 @@ static int SimInitializeEngine(void)
 	if (!Simulator.Options->debug_dsky)
 	{
 		if (Simulator.Options->resume == NULL)
-	    {
+		{
 			if (Simulator.Options->cfg)
-	    	{
+			{
 				if (CmOrLm)
 				{
 					result = agc_engine_init (&Simulator.State,
@@ -77,17 +77,22 @@ static int SimInitializeEngine(void)
 							Simulator.Options->core, "LM.core", 0);
 				}
 			}
-	    	else
-	    	{
-	    		result = agc_engine_init (&Simulator.State,
-	    				Simulator.Options->core,"core", 0);
-	    	}
-	    }
-	    else
-	    {
-	    	result = agc_engine_init (&Simulator.State,
-	    			Simulator.Options->core, Simulator.Options->resume, 1);
-	    }
+			else if (Simulator.Options->no_resume)
+			{
+				result = agc_engine_init (&Simulator.State,
+						Simulator.Options->core, NULL, 0);
+			}
+			else
+			{
+				result = agc_engine_init (&Simulator.State,
+						Simulator.Options->core, "core", 0);
+			}
+		}
+		else
+		{
+			result = agc_engine_init (&Simulator.State,
+					Simulator.Options->core, Simulator.Options->resume, 1);
+		}
 
 		/* Check AGC Engine Init Result and display proper message */
 		switch (result)


### PR DESCRIPTION
By default yaAGC looks for a file called `core` to reload the state of the erasable from a previous run. This is done to mimic the behavior of the non-volatile erasable memory used in the AGC and as a convenient option to continue running the program at a later time. However I don't always want to resume with a previous memory state and start completely fresh instead. My workflow used to consist of:
1. Run yaAGC
2. Make a change and recompile the rope
3. Remove the core file
4. Run yaAGC again.

There are occasions where I make small changes to a rope in quick succession and having to remove the core file gets old very fast. Or one might for example want to do a fresh run and compare that to a saved state later.

This commit adds a new convenience option to yaAGC, `--no-resume`, which allows you to skip the reloading of erasable and start with a completely fresh state instead, compressing steps 3 and 4 in my workflow. I've had this commit in a local copy of virtualagc for a couple of years now and it's proven to be useful to me, perhaps others might also find this option useful.