### PR TITLE
yaYUL: Added VXM* support for Block I

### DIFF
--- a/yaYUL/Pass.c
+++ b/yaYUL/Pass.c
@@ -1206,6 +1206,7 @@ static InterpreterMatch_t InterpreterOpcodesBlock1[] =
     { "VSRT*", 0025 },
     { "VSU", 0163 },
     { "VXM", 0047 },
+    { "VXM*", 0045 },
     { "VXSC", 0167 },
     { "VXSC*", 0165 },
     { "VXV", 0007 },


### PR DESCRIPTION
I did a rough first-pass disassembly of the MEASUREMENT INCORPORATION log section of Corona 261 tonight, and came across two instances of `VXM*`, which yaYUL doesn't currently know how to assemble for Block I. This rectifies that.