### PR TITLE
Sundial E: disentangle illegally-placed patches

### DIFF
--- a/SundialE/AGC_BLOCK_TWO_SELF-CHECK.agc
+++ b/SundialE/AGC_BLOCK_TWO_SELF-CHECK.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Added note for patches introduced in Sundial D.
 
 
                 BANK    10
@@ -1218,7 +1219,9 @@ DV5--           EXTEND
                 INCR    SCOUNT +2
                 TC      SELFCHK         # START SELF-CHECK AGAIN
 
-
+## MAS 2023: The following two chunks of code were added as patches
+## in Sundial D. They were placed here at the end of the bank so
+## as to not change addresses of existing symbols.
 
 ERASLP1         EXTEND
                 INDEX   SKEEP7

--- a/SundialE/FRESH_START_AND_RESTART.agc
+++ b/SundialE/FRESH_START_AND_RESTART.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Relocated Sundial D patches to T4RUPT PROGRAM.
 
                 BANK    12
                 EBANK=  LST1
@@ -365,27 +366,3 @@ SWINIT          OCT     0
                 OCT     0
 
 ENDFRESS        EQUALS
-
-## MAS 2023: The following chunks of code were added as patches
-## in Sundial D. They were placed here at the end of the bank
-## so as to not change addresses of existing symbols.
-                SETLOC  ENDT4S
-
-GOPROG1         INCR    REDOCTR         # ADVANCE RESTART COUNTER.
-
-                CA      ERESTORE
-                EXTEND
-                BZF     GOPROG +1
-
-                EXTEND                  # RESTORE B(X) AND B(X+1) IF RESTART
-                DCA     SKEEP5          # HAPPENED WHILE SELF-CHECK HAD REPLACED
-                NDX     SKEEP7          # THEM WITH CHECKING WORDS.
-                DXCH    0000
-
-                TC      GOPROG +1
-
-STARTSB1        TS      ERESTORE
-                CAF     PRIO34          # ENABLE INTERRUPTS.
-                TC      STARTSB2
-
-ENDFRPS         EQUALS

--- a/SundialE/IMU_MODE_SWITCHING_ROUTINES.agc
+++ b/SundialE/IMU_MODE_SWITCHING_ROUTINES.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Relocated Sundial D patch to SXTMARK.
 
 
                 SETLOC  ENDT4FF
@@ -699,28 +700,3 @@ IMUSEFLG        EQUALS  BIT8            # INTERPRETER SWITCH 7.
 90SEC           DEC     9000
 
 ENDIMODS        EQUALS
-
-
-## MAS 2023: The following chunk of code was added as a patch
-## in Sundial D. It was placed here at the end of the bank
-## so as to not change addresses of existing symbols.
-                SETLOC  ENDAMODS
-
-IMUZERO1        CAF     BIT4            # DONT ZERO CDUS IF IMU IN GIMBAL LOCK AND
-                EXTEND                  # COARSE ALIGN.
-                RAND    12
-                DOUBLE
-                DOUBLE
-                MASK    DSPTAB +11D
-                CCS     A
-                TCF     +3
-
-                CS      IMUSEFLG
-                TCF     IMUZERO +2
-
-                TC      ALARM           # IF SO.
-                OCT     206
-
-                TCF     CAGETSTJ +4
-
-ENDIMPS         EQUALS

--- a/SundialE/LIST_PROCESSING_INTERPRETER.agc
+++ b/SundialE/LIST_PROCESSING_INTERPRETER.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Corrected a corrupted comment and some whitespace.
 
 
 # SECTION 1  DISPATCHER
@@ -1312,7 +1313,7 @@ DV/SC           EXTEND
 
 SIGN            INDEX   ADDRWD          # CALL COMP INSTRUCTION IF WORD AT X IS
                 CCS     0               # NEGATIVE NON-ZERO.
-                TCF     NOIBNKSW		# NO FTCH REQUIRED.
+                TCF     NOIBNKSW        # NO FBANK SWITCH REQUIRED.
                 TCF     +2
                 TCF     COMP            # DO THE COMPLEMENT.
 
@@ -2645,11 +2646,11 @@ ACOS3           DXCH    MPAC            # SET UP FOR POLYNOMIAL EVALUATION.
 
                 2DEC*   +.00695311612 B+4*
 
-                2DEC*   -.00384617957   B+5*
+                2DEC*   -.00384617957 B+5*
 
-                2DEC*   +.001501297736  B+6*
+                2DEC*   +.001501297736 B+6*
 
-                2DEC*   -.000284160334  B+7*
+                2DEC*   -.000284160334 B+7*
 
                 CAF     LBUF2           # DO FINAL MULTIPLY AND GO TO ANY
                 TC      DMPSUB -1       # EPILOGUE SEQUENCES.

--- a/SundialE/PINBALL_GAME__BUTTONS_AND_LIGHTS.agc
+++ b/SundialE/PINBALL_GAME__BUTTONS_AND_LIGHTS.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Corrected a corrupted comment and some whitespace.
 
 
 
@@ -2159,7 +2160,7 @@ MMCHANG         TC      REQMM
                 TC      POSTJUMP
                 CADR    MODROUTB        # GO THRU STANDARD LOC.
 
-MODROUTB        =       DSPALARM                # **FI*
+MODROUTB        =       DSPALARM        # **FIX LATER**
 REQMM           CS      Q
                 TS      REQRET
                 CAF     ND1
@@ -2960,7 +2961,7 @@ SETNCADR        TS      NOUNCADR        # STORE ECADR
 #               E ADRES AND PUTS IT INTO NOUNADD.
 
 SETNADD         CA      NOUNCADR
-                TCF     SETNCADR        +1
+                TCF     SETNCADR +1
 
 
 

--- a/SundialE/SUM_CHECK_END_OF_BANK_MARKERS.agc
+++ b/SundialE/SUM_CHECK_END_OF_BANK_MARKERS.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Updated tags for new patch placement.
 
 
                 SETLOC  ENDIMUF
@@ -54,11 +55,11 @@
                 TC
                 TC
 
-                SETLOC  ENDFRPS
+                SETLOC  ENDT4S
                 TC
                 TC
 
-                SETLOC  ENDIMPS
+                SETLOC  ENDSMODS
                 TC
                 TC
 

--- a/SundialE/SXTMARK.agc
+++ b/SundialE/SXTMARK.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Moved in patch from IMU MODE SWITCHING ROUTINES.
 
 
                 SETLOC  ENDIMODS
@@ -323,4 +324,26 @@ MKDSPCOD        OCT     00656
 LREMKDSP        CADR    REMKDSP
 OCT37           OCT     37
 OCT76           OCT     76
-ENDAMODS        EQUALS
+
+## MAS 2023: The following chunk of code was added as a patch
+## in Sundial D. It was placed here at the end of the bank
+## so as to not change addresses of existing symbols.
+
+IMUZERO1        CAF     BIT4            # DONT ZERO CDUS IF IMU IN GIMBAL LOCK AND
+                EXTEND                  # COARSE ALIGN.
+                RAND    12
+                DOUBLE
+                DOUBLE
+                MASK    DSPTAB +11D
+                CCS     A
+                TCF     +3
+
+                CS      IMUSEFLG
+                TCF     IMUZERO +2
+
+                TC      ALARM           # IF SO.
+                OCT     206
+
+                TCF     CAGETSTJ +4
+
+ENDSMODS        EQUALS

--- a/SundialE/T4RUPT_PROGRAM.agc
+++ b/SundialE/T4RUPT_PROGRAM.agc
@@ -12,6 +12,7 @@
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-22 MAS  Created from Aurora 12.
 ##              2023-06-30 MAS  Updated for Sundial E.
+##              2023-07-03 MAS  Moved in patches from FRESH START AND RESTART.
 
 
                 SETLOC  ENDPHMNF
@@ -965,5 +966,22 @@ OPONLY1         CAF     BIT4
 
                 CAF     IMUSEFLG        # OTHERWISE, ZERO THE COUNTERS
                 TCF     OPONLY +1
+
+GOPROG1         INCR    REDOCTR         # ADVANCE RESTART COUNTER.
+
+                CA      ERESTORE
+                EXTEND
+                BZF     GOPROG +1
+
+                EXTEND                  # RESTORE B(X) AND B(X+1) IF RESTART
+                DCA     SKEEP5          # HAPPENED WHILE SELF-CHECK HAD REPLACED
+                NDX     SKEEP7          # THEM WITH CHECKING WORDS.
+                DXCH    0000
+
+                TC      GOPROG +1
+
+STARTSB1        TS      ERESTORE
+                CAF     PRIO34          # ENABLE INTERRUPTS.
+                TC      STARTSB2
 
 ENDT4S          EQUALS


### PR DESCRIPTION
While working on the Aurora 88 disassembly, I ran into what I briefly thought might have been a bug in yaYUL. In attempting to keep patches co-located with the code being patched, I created an inadvertent circular SETLOC chain, caused by the `SETLOC` for a patch in bank 13 preceding the first `BANK 13`  card in the listing. yaYUL gave up after 10 passes and produced no output.

I thought for a moment that perhaps the original Yul might be able to handle this situation, so I whipped up a punch card deck and threw it into pyul. It didn't even get as far as yaYUL did before barfing. The cuss it gave me, however, made me question some of what I had done in Sundial E.

So I put together a simple test program and fed it into both yaYUL and pyul:
```
            BANK    10
ZERO        OCT     0
END1        EQUALS

            SETLOC  END2
ONE         OCT     1

            SETLOC  END1
TWO         OCT     2
END2        EQUALS
```

It's a minimal reproducing case for how I placed some of the patches in Sundial E.  This should in theory allocate the constants in the order ZERO, TWO, ONE. yaYUL can assemble this chunk without any errors, and gets the order correct. No surprise there. pyul, however, cusses about it:
```
 0001                                  10,2000           BANK   10
 0002                        10,2000   00000 1  ZERO     OCT    0

 0003                                  10,2001  END1     EQUALS
 0004   REF   1                           ■■■■           SETLOC END2
E■■■■■■ # 1     "END2    " WAS UNDEFINED IN PASS 1
 0005                        10,2001   00001 0  ONE      OCT    1

 0006   REF   1                        10,2001           SETLOC END1
 0007                        10,2001   00002 0  TWO      OCT    2
E■■■■■■ # 2     CONFLICT IN USE OF THIS LOCATION
E■■■■■■ # 2     "TWO     " ASSOCIATED WITH CONFLICT
 0008                                  10,2002  END2     EQUALS
```

In other words, yaYUL is actually being a bit more powerful here than the original Yul, and let me do some things that should have been illegal. This MR unwinds that illegal SETLOCing, at the cost of patches moving to files that have nothing to do with the code being patched. We've seen that in some of the listings we have (e.g. Comanche places patches for the gravity model in RTB OPCODES), so this being a restriction is totally believable. I also fixed a few corrupted comments and corrected a bit of whitespace.