### PR TITLE
yaYUL: Generalize treatment of empty arguments as referring to the current location

### DIFF
--- a/yaYUL/ParseEQUALS.c
+++ b/yaYUL/ParseEQUALS.c
@@ -35,6 +35,8 @@
  *                              found some places in SUNBURST.  However, I
  *               01/29/17 MAS   Added an address calculation tweak for
  *                              the --raytheon option.
+ *               07/12/23 MAS   Made empty string symbols evaluate to the
+ *                              current program counter.
  */
 
 #include "yaYUL.h"
@@ -65,6 +67,12 @@ FetchSymbolPlusOffset(Address_t *pc, char *Operand, char *Mod1,
   Symbol_t *Symbol;
   Address_t dummyAddress;
   int i, Offset;
+
+  if (Operand[0] == '\0')
+    {
+      *Value = *pc;
+      return (0);
+    }
 
   i = GetOctOrDec(Operand, &Offset);
   if (!i)


### PR DESCRIPTION
Aurora 88 contains some placeholder code where it's pretty apparent that they inserted the desired opcodes, but didn't fill in the arguments which were not yet defined:
```
                RESUME                  # HAND CONTROL RUPT   ***FIX LATER****
                CA
                XCH     BBANK
                TCF
```

In the original Yul, any empty arguments like that evaluate to the current address. yaYUL already supports this for TC, TCF, and CADR, since those are specific cases that have appeared in other listings, but it currently throws errors for the CA. This change generalizes the handling of empty-string symbols, so they evaluate to the current address.

Running this code through both pyul and yaYUL now produces the following results:
```
                BANK    10
                LOC     +123

                CS
                CA
                TS
                AD
```

pyul gives:
```
 0001                                  10,2000           BANK   10
 0002                                  10,2123           LOC    +123

 0003                        10,2123  4 2123 1           CS
 0004                        10,2124  3 2124 1           CA
 0005                        10,2125  5 ■■■■             TS
E■■■■■■ # 1     RANGE ERROR IN VALUE OF ADDRESS
E■■■■■■ # 1     ADDRESS =10,2125
 0006                        10,2126  6 2126 0           AD
```

yaYUL with this change gives:
```
000001,000001: 10,2000                                           BANK     10
000002,000002: 10,2123                                           LOC      +123
000003,000003:
000004,000004: 10,2123           42123                           CS
000005,000005: 10,2124           32124                           CA
test.agc:6: Fatal Error: Operand (0125) out of range.
test.agc:6: Fatal Error: Operand (0125) out of range.
000006,000006: 10,2125           54125                           TS
000007,000007: 10,2126           62126                           AD
```