### PR TITLE
Sundial E: minor PRELAUNCH changes, based on Aurora 88 disassembly

### DIFF
--- a/SundialE/PRELAUNCH_ALIGNMENT_PROGRAM.agc
+++ b/SundialE/PRELAUNCH_ALIGNMENT_PROGRAM.agc
@@ -11,6 +11,9 @@
 ## Contact:     Ron Burkey <info@sandroid.org>.
 ## Website:     www.ibiblio.org/apollo/index.html
 ## Mod history: 2023-06-30 MAS  Created.
+##              2023-07-12 MAS  Changed an unused constant to a TC GRABWAIT,
+##                              and a WANGI reference to XSM1 +16D, based on
+##                              disassembly of equivalent code in Aurora 88.
 
                 BANK    15
                 EBANK=  XSM
@@ -53,8 +56,8 @@ LODLATAZ        EXTEND
                 TC      LODLATAZ +2
 
 V06N61E         OCT     00661
-UNUSED1         OCT     05550
 
+                TC      GRABWAIT
 STARTPL         TC      NEWMODEX
                 OCT     01
                 EXTEND
@@ -173,7 +176,7 @@ ZEROS1          TS      MPAC
                         OPTUSE
                 STODL   XSM1 +6
                         GEOCONS5
-                STORE   WANGI
+                STORE   XSM1 +16D
                 EXIT
 
                 INHINT


### PR DESCRIPTION
Aurora 88 has a nearly-identical copy of this code, which has given me a means of cross-referencing some of the more mysterious things. This turned up two errors:
- What I thought was an unused constant is instead apparently an (unreferenced?) `TC GRABWAIT`.
- A place where I had used the label `WANGI` should instead apparently be `XSM1 +16D`. `WANGI` and `XSM1 +16D` share an address in Sundial E, but not in Aurora 88. The code is identical, as is the offset between XSM1 and the word in question, so `WANGI` must not be correct.