### PR TITLE
yaLVDC: Assorted fixes for CDS, MPY/MPH, and debugging

### DIFF
--- a/yaLVDC/gdbInterface.c
+++ b/yaLVDC/gdbInterface.c
@@ -36,6 +36,7 @@
  * Reference:   http://www.ibibio.org/apollo
  * Mods:        2020-04-30 RSB  Began.
  *              2020-05-21 RSB  Fixed arguments for DISASSEMBLE.
+ *              2023-07-16 MAS  Fixed handling of SI and NI.
  */
 
 #include <stdlib.h>
@@ -176,9 +177,9 @@ typedef struct
 commandAssociation_t commandAssociations[] =
       {
         { ctSTEP, "STEPI", "STEPI [n]", "Step n instructions, default n=1." },
-        { ctSTEP, "STEPI", "SI [n]", "Same as STEPI." },
+        { ctSTEP, "SI", "SI [n]", "Same as STEPI." },
         { ctNEXT, "NEXTI", "NEXTI [n]", "Next n instructions, w/o entry." },
-        { ctNEXT, "NEXTI", "NI [n]", "Same as NEXTI." },
+        { ctNEXT, "NI", "NI [n]", "Same as NEXTI." },
         { ctDELETE, "DELETE", "DELETE", "Delete all breakpoints." },
         { ctDELETE, "DELETE", "DELETE n", "Delete breakpoint n." },
         { ctCONTINUE, "CONTINUE", "CONTINUE", "Continue running emulation." },


### PR DESCRIPTION
- The debug interface wasn't correctly accepting `SI` and `NI`
- CDS shouldn't require A8 to be 0:
![image](https://github.com/virtualagc/virtualagc/assets/94056/de7ed4b1-6e05-4a5c-bb22-c9a1d740663e)
- MPH was not automatically loading PQ into the accumulator. This is mechanized in the LVDC by forcing the instruction `CLA 775` to automatically occur 4 times after the `MPH` instruction. The last one grabs the final product.
![image](https://github.com/virtualagc/virtualagc/assets/94056/3298683f-686d-41b7-b78d-803361834a9d)
- MPH and MPY were producing very bad results at first, and then mostly-correct-but-sometimes-off-by-one results once the gross error was fixed. I couldn't for the life of me find a reliable way to determine if the result was going to be off by one or not. But I did find that a naive implementation of the algorithm described in paragraph 2-319 of the laboratory maintenance instructions lead to results that match the simulator in every case I have thrown at it so far. It's less efficient than native multiplication, obviously, but it's only 6 iterations and the LVDC is a slow computer.
![image](https://github.com/virtualagc/virtualagc/assets/94056/83f491a4-6f67-48e5-9b4f-20a1dcf3cf89)
![image](https://github.com/virtualagc/virtualagc/assets/94056/dc2f9d63-d47c-4c3f-a871-0b1aec8225e3)

