### PR TITLE
yaLVDC: Correctly handle negative multiplicands for MPY/MPH

### DIFF
--- a/yaLVDC/runOneInstruction.c
+++ b/yaLVDC/runOneInstruction.c
@@ -588,7 +588,7 @@ runOneInstruction(int *cyclesUsed)
       // results from this approach, presumably due to differences in
       // precision.
       int multiplier = (state.acc >> 1) & ~1;
-      int multiplicand = fetchedFromMemory & ~3;
+      int multiplicand = convertDataWordToNative(fetchedFromMemory) & ~3;
       dummy = 0;
       for (uint8_t i = 0; i < 6; i++)
         {


### PR DESCRIPTION
Throwing more test cases at my MPY implementation led me to discover it wasn't correctly handling negative multiplicands (negative multipliers were fine). This tweak fixes that.

The test cases I'm running it through are [here](https://github.com/thewonderidiot/lvdc_simulation/blob/f70e27eef1abb9d7f3f35358c32761f05b195e78/self-test/self-test.lvdc#L1010). This is a port of the PTC self-test program that I'm making for the LVDC. I expanded all of the applicable tests to try to more fully cover LVDC functionality, and am now starting to add test cases for MPY, MPH, DIV, and EXM. All of these MPH cases are passing now in both yaLVDC and my simulator.

The best "source of truth" I've found for a correct multiply result is this little chunk in the AS-512 software:
```
GP2291 CLA     775          FORMAT N.S. Q-C TABLE POINTER             B
       MPY     D.KB13       SCALE SY1 INSTRUCTION TO SY0
```

That comment implies to me that this should be equivalent to a "shift right by 13". This particular case is covered by the first MPH test case in the self-test program, L8P1.

The updated hacky python test code is:
```py
acc = (0o231463146>>2) & (~1)
mcd = (0o512172702>>1)

if mcd & 0o200000000:
    mcd ^= 0o377777777
    mcd = -(mcd + 1)
mcd &= ~3

def delta1(a, m):
    b = (a >> 0) & 0o7
    if b in (0,7):
        return 0
    elif b in (1,2):
        return 2*m
    elif b == 3:
        return 4*m
    elif b == 4:
        return -4*m
    elif b in (5,6):
        return -2*m

def delta2(a, m):
    b = (a >> 2) & 0o7
    if b in (0,7):
        return 0
    elif b in (1,2):
        return 8*m
    elif b == 3:
        return 16*m
    elif b == 4:
        return -16*m
    elif b in (5,6):
        return -8*m

p = 0

for i in range(6):
    p += delta2(acc, mcd) + delta1(acc, mcd)
    p >>= 4
    acc >>= 4

print(oct(p & 0o377777777))
```