### PR TITLE
yaLVDC: Corrections for MPY partial products and DIV

### DIFF
--- a/yaLVDC/yaLVDC.h
+++ b/yaLVDC/yaLVDC.h
@@ -32,6 +32,9 @@
  * Reference:   http://www.ibibio.org/apollo
  * Mods:        2019-09-18 RSB  Began.
  *              2020-04-29 RSB  Added the --ptc switch.
+ *              2023-07-28 MAS  Added a multiply/divide counter and
+ *                              registers to hold intermediate PQR
+ *                              multiplication/division results.
  */
 
 #ifndef yaLVDC_h
@@ -156,6 +159,9 @@ typedef struct
   int32_t hop;
   int32_t acc;
   int32_t pq;
+  int32_t pqPend1;
+  int32_t pqPend2;
+  int32_t mpyDivCount;
   int32_t hopSaver; // otherwise known as the "HOP saver" register.
   int32_t core[8][16][3][256];
   int32_t pio[01000];


### PR DESCRIPTION
* MPY and DIV continuously update PQR, making it unsuitable for temporary storage while they're in progress. I added a countdown tracking their progress, and changed runOneInstruction() to update PQR at the end of every cycle with results. Ongoing MPYs and DIVs also inhibit interrupts from the LVDC side, which I don't think is happening yet, so I'm planning on dual-purposing this counter for interrupt checks when I get to fleshing out interrupt handling.
* The LVDC documentation claims that for MPY, the partial product of the multiplicand with the lower 12 bits of the accumulator is available to the 2nd instruction following the MPY. It turns out this is true, but not in the way we initially thought. This product is formed as though those lower 12 bits were the _most_ significant bits rather than the least significant bits.
![image](https://github.com/virtualagc/virtualagc/assets/94056/98c77fdd-316f-4795-b8dc-2e7946e5b6ed)
Luckily, because I replaced yaLVDC's MPY implementation with the algorithm implemented in the hardware, we were already calculating the correct partial product and discarding it. It's not easy to replicate the garbage that shows up in PQR during the 1st and 3rd instructions following MPY, so what I've done for now is make this partial product appear for instructions 1-3, and the final product only appear for the 4th instruction.
* DIV scaling was off and has been corrected. This is giving good results and I haven't found any bad cases for it yet, so this may or may not be the final DIV implementation pending further self-tests. It has no such partial product requirement, so I made it put 0 into PQR for the first 7 instructions and only make the full result available for the 8th.