### PR TITLE
yaDSKYb1 Fixes

### DIFF
--- a/yaDSKYb1/Makefile
+++ b/yaDSKYb1/Makefile
@@ -20,7 +20,7 @@ endif
 all default:	yaDSKYb1
 
 yaDSKYb1: yaDSKYb1-widgetized.cpp yaDSKYb1-widgetized.h ${EXTRASOURCE} ${EXTRAHEADERS} Makefile
-	${CC} -g -O0 -DMAIN_DSKY_WIDGETIZED `wx-config --cxxflags` ${wxFLAGS} -I/usr/lib/wx/include/gtk3-unicode-3.2/ -I/usr/include/wx-3.2/ \
+	${CC} -g -O0 -DMAIN_DSKY_WIDGETIZED `wx-config --cxxflags` ${wxFLAGS} \
 		$< ${EXTRASOURCE} `wx-config --libs` -o $@ $(NLIBS)
 
 .PHONY: clean

--- a/yaDSKYb1/Makefile
+++ b/yaDSKYb1/Makefile
@@ -20,7 +20,7 @@ endif
 all default:	yaDSKYb1
 
 yaDSKYb1: yaDSKYb1-widgetized.cpp yaDSKYb1-widgetized.h ${EXTRASOURCE} ${EXTRAHEADERS} Makefile
-	${CC} -g -O0 -DMAIN_DSKY_WIDGETIZED `wx-config --cxxflags` ${wxFLAGS} \
+	${CC} -g -O0 -DMAIN_DSKY_WIDGETIZED `wx-config --cxxflags` ${wxFLAGS} -I/usr/lib/wx/include/gtk3-unicode-3.2/ -I/usr/include/wx-3.2/ \
 		$< ${EXTRASOURCE} `wx-config --libs` -o $@ $(NLIBS)
 
 .PHONY: clean

--- a/yaDSKYb1/yaDSKYb1-widgetized.cpp
+++ b/yaDSKYb1/yaDSKYb1-widgetized.cpp
@@ -604,7 +604,7 @@ MyFrame::do_layout()
       sizer_12_copy_1->Add(digitNounRight, 0, 0, 0);
       sizer_12_copy_1->Add(12, 20, 0, 0, 0);
       grid_sizer_3->Add(sizer_12_copy_1, 0, 0, 0);
-      sizer_3->Add(grid_sizer_3, 0, wxALIGN_CENTER_VERTICAL, 0);
+      sizer_3->Add(grid_sizer_3, 0, wxALIGN_CENTER_HORIZONTAL, 0);
       sizer_3->Add(20, 22, 0, 0, 0); // Between Reg1 and Verb/Noun
       grid_sizer_2->Add(PlusMinusReg1, 0, 0, 0);
       grid_sizer_2->Add(Digit1Reg1, 0, 0, 0);

--- a/yaDSKYb1/yaDSKYb1.cpp
+++ b/yaDSKYb1/yaDSKYb1.cpp
@@ -290,7 +290,7 @@ TimerClass::Notify()
   if (frame->flashing)
     {
       frame->flashCounter++;
-      if (frame->flashCounter >= 1000 / PULSE_INTERVAL)
+      if (frame->flashCounter >= 700 / PULSE_INTERVAL)
         {
           frame->flashCounter = 0;
           frame->flashStateLit = !frame->flashStateLit;
@@ -512,9 +512,9 @@ TimerClass::ActOnIncomingIO(unsigned char *Packet)
       lastOUT1 = Value;
       frame->indicatorProgAlm->SetBitmap(
           (0 == (Value & 01)) ? frame->imageProgAlmOff : frame->imageProgAlmOn);
-      frame->indicatorCompFail->SetBitmap(
+      frame->indicatorComp->SetBitmap(
           (0 == (Value & 02)) ?
-              frame->imageCompFailOff : frame->imageCompFailOn);
+              frame->imageCompOff : frame->imageCompOn);
       frame->indicatorKeyRlse->SetBitmap(
           (0 == (Value & 04)) ? frame->imageKeyRlseOff : frame->imageKeyRlseOn);
       frame->indicatorScalerFail->SetBitmap(

--- a/yaDSKYb1/yaDSKYb1.cpp
+++ b/yaDSKYb1/yaDSKYb1.cpp
@@ -517,9 +517,9 @@ TimerClass::ActOnIncomingIO(unsigned char *Packet)
               frame->imageCompOff : frame->imageCompOn);
       frame->indicatorKeyRlse->SetBitmap(
           (0 == (Value & 04)) ? frame->imageKeyRlseOff : frame->imageKeyRlseOn);
-      frame->indicatorScalerFail->SetBitmap(
+      frame->indicatorTmFail->SetBitmap(
           (0 == (Value & 010)) ?
-              frame->imageScalerFailOff : frame->imageScalerFailOn);
+              frame->imageTmFailOff : frame->imageTmFailOn);
       frame->indicatorCheckFail->SetBitmap(
           (0 == (Value & 020)) ?
               frame->imageCheckFailOff : frame->imageCheckFailOn);

--- a/yaDSKYb1/yaDSKYb1.cpp
+++ b/yaDSKYb1/yaDSKYb1.cpp
@@ -45,11 +45,12 @@
  *              2023-08-14 JAP  Fixed the COMP FAIL and SCALER FAIL lights
  *                              illuminating instead of the COMP ACTY and TM FAIL
  *                              lights, respectively. Also sped up the VERB/NOUN
- *                              flashing from a period of 1000 ms to 781.25 ms, per
- *                              the ND-1021041 document and relevant schematics.
- *                              Additionally removed a 200 ms wait from the packet
- *                              output code, and fixed a warning about an incorrect
- *                              grid sizer alignment object on program startup.
+ *                              flashing to 0.78125 Hz or 1.28 seconds (640 ms on,
+ *                              640 ms off), per the ND-1021041 document and
+ *                              relevant schematics. Additionally removed a
+ *                              200 ms wait from the packet output code, and fixed
+ *                              a warning about an incorrect grid sizer
+ *                              alignment object on program startup.
  */
 
 #include <sys/types.h>
@@ -298,7 +299,7 @@ TimerClass::Notify()
   if (frame->flashing)
     {
       frame->flashCounter++;
-      if (frame->flashCounter >= 78125 / 100 / PULSE_INTERVAL)
+      if (frame->flashCounter >= 640 / PULSE_INTERVAL)
         {
           frame->flashCounter = 0;
           frame->flashStateLit = !frame->flashStateLit;

--- a/yaDSKYb1/yaDSKYb1.cpp
+++ b/yaDSKYb1/yaDSKYb1.cpp
@@ -290,7 +290,7 @@ TimerClass::Notify()
   if (frame->flashing)
     {
       frame->flashCounter++;
-      if (frame->flashCounter >= 700 / PULSE_INTERVAL)
+      if (frame->flashCounter >= 78125 / 100 / PULSE_INTERVAL)
         {
           frame->flashCounter = 0;
           frame->flashStateLit = !frame->flashStateLit;

--- a/yaDSKYb1/yaDSKYb1.cpp
+++ b/yaDSKYb1/yaDSKYb1.cpp
@@ -378,7 +378,6 @@ OutputKeycode(int Keycode)
         }
       else
         {
-          wxMilliSleep(200);
           FormIoPacket(04, 0, &Packet[4]); // Data.
           j = send(ServerSocket, (const char *) Packet, 8, MSG_NOSIGNAL);
           if (j == SOCKET_ERROR && SOCKET_BROKEN)

--- a/yaDSKYb1/yaDSKYb1.cpp
+++ b/yaDSKYb1/yaDSKYb1.cpp
@@ -42,6 +42,14 @@
  *                              used, and it's really flashing of the verb and noun
  *                              *digits* themselves, just as it is for Block 2.  So
  *                              I've fixed that.
+ *              2023-08-14 JAP  Fixed the COMP FAIL and SCALER FAIL lights
+ *                              illuminating instead of the COMP ACTY and TM FAIL
+ *                              lights, respectively. Also sped up the VERB/NOUN
+ *                              flashing from a period of 1000 ms to 781.25 ms, per
+ *                              the ND-1021041 document and relevant schematics.
+ *                              Additionally removed a 200 ms wait from the packet
+ *                              output code, and fixed a warning about an incorrect
+ *                              grid sizer alignment object on program startup.
  */
 
 #include <sys/types.h>


### PR DESCRIPTION
This fixes several inaccuracies and other issues with yaDSKYb1, found when developing my own Block I AGC emulator:
- The COMP FAIL light illuminates instead of the COMP ACTY light
- The SCALER FAIL light illuminates instead of the TM FAIL light
- The flashing pace of the Verb/Noun display was too slow, documentation stating "roughly once per second" was exaggerating: it's actually the FS17 timing signal from the scaler, which has a frequency of 0.78125 Hz, or a period of 1.28 seconds (640 ms on, 640 ms off).
- Launching the program would display a warning message about an incorrect grid sizer alignment object.
- There was an unnecessary 200 ms delay in part of the packet-sending code (recommended to remove by @thewonderidiot )
