### PR TITLE
yaAGC: Clear more internal state on GOJAM

### DIFF
--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -377,6 +377,15 @@
  *				here, and that its presence isn't too desirable for
  *				those who are porting minimized implementations,
  *				so I've commented it out.
+ *		01/03/24 MAS	Changed GOJAM simulation to clear out a lot more
+ *				yaAGC-internal state that doesn't necessarily
+ *				exactly match hardware GOJAM actions, but needs
+ *				to be cleared out nevertheless due to how yaAGC
+ *				is implemented. This is necessary to fix a
+ *				longstanding bug where the AGC would fail to
+ *				correctly exit standby, due to corruption of the
+ *				first instruction at address 4000 (usually by a
+ *				non-zero IndexValue).
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,
  * or more particularly for the Apollo Guidance Computer (AGC) may be found at
@@ -2222,6 +2231,15 @@ agc_engine (agc_t * State)
               CpuWriteIO(State, 034, 0);
               CpuWriteIO(State, 035, 0);
               State->DownruptTimeValid = 0;
+
+              // Clear other yaAGC-internal state
+              State->IndexValue = AGC_P0;
+              State->ExtraCode = 0;
+              State->SubstituteInstruction = 0;
+              State->PendFlag = 0;
+              State->PendDelay = 0;
+              State->TookBZF = 0;
+              State->TookBZMF = 0;
 
               // Light the RESTART light on the DSKY, if we're not going into standby
               if (!State->Standby)


### PR DESCRIPTION
There's been an elusive longstanding bug seen in NASSP where the AGC would fail to correctly exit standby mode. Instead of sending the user to a flashing V37, the computer would instead pick right back up at the pre-standby V50 N25 display, sometimes accompanied by a RESTART light. This failure to come out of standby mode meant the clocks weren't updated with elapsed time from the scaler, and sometimes seemingly led to weird behavior we couldn't really explain.

@indy91 and I finally tracked it down a couple of days ago. It turns out that our simulation of hardware restarts (including standby entry) through the GOJAM signal was complete per the hardware-level description in [Digital Development memo 340](https://www.ibiblio.org/apollo/Documents/dd_memo_340.pdf), but neglected to reset non-hardware yaAGC internal state that nevertheless is critically important. This PR is an attempt to track down and reset all such state.

The main thing that we identified as the major culprit is `IndexValue`. The computer sometimes restarts immediately after an INDEX instruction, leaving `IndexValue` set to the modifier to be applied to the next instruction. Since this wasn't being reset to 0, this modifier was instead being applied to the first instruction of the reset vector -- i.e. the INHINT instruction at address 4000 -- changing it to something other than an INHINT. Since INDEX values are *usually* small, this *usually* changed that INHINT into a TC, causing the computer to jump off to somewhere random in memory and start executing code there, wreaking general havoc until another restart followed.

The remainder of the stuff I'm resetting here is everything else I could identify from `agc_t` that seemed necessary to get execution back to a clean slate. All of the scaler-controlled timing things like hardware alarm flip-flops are intentionally not included, since they are not reset by GOJAM in the real computer. I think I got it all, but a second pair of eyes on that struct to see if anything else should be reset would be appreciated.