### PR TITLE
yaAGC: Implement internally-timed RADARUPTs

### DIFF
--- a/yaAGC/NullAPI.c
+++ b/yaAGC/NullAPI.c
@@ -41,6 +41,9 @@
 				the GPL, for linking to Orbiter SDK libraries.
 		05/14/05 RSB	Corrected website references.
 		05/31/05 RSB	Added ShiftToDeda.
+		01/29/24 MAS	Added a stub RequestRadarData function for use
+				by integrators of yaAGC into spacecraft
+				simulations.
 */
 
 #ifdef WIN32
@@ -182,4 +185,12 @@ ShiftToDeda (agc_t *State, int Data)
 {
 }
 
-
+//----------------------------------------------------------------------
+// This function is provided as a stub for integrators of yaAGC into
+// more complete simulations. It is expected to populate the counter
+// RNRAD with radar data.
+void
+RequestRadarData (agc_t *State)
+{
+    // State->Erasable[0][RegRNRAD] = 012345;
+}

--- a/yaAGC/SocketAPI.c
+++ b/yaAGC/SocketAPI.c
@@ -77,6 +77,9 @@
 				same size as data packets.  Otherwise, it makes
 				low-level debugging of the streaming data hard,
 				because the packet alignment changes over time.
+		01/29/24 MAS	Added a stub RequestRadarData function for use
+				by integrators of yaAGC into spacecraft
+				simulations.
 */
 
 #include <errno.h>
@@ -502,4 +505,12 @@ ShiftToDeda (agc_t *State, int Data)
     send (Client->Socket, (const char *) Packet, 4, MSG_NOSIGNAL);
 }
 
-
+//----------------------------------------------------------------------
+// This function is provided as a stub for integrators of yaAGC into
+// more complete simulations. It is expected to populate the counter
+// RNRAD with radar data.
+void
+RequestRadarData (agc_t *State)
+{
+    // State->Erasable[0][RegRNRAD] = 012345;
+}

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -119,6 +119,8 @@
 				so the light would still work in standby.
 		02/11/20 TVB	Disabled a compiler warning under MSC for some stdio
 				functions that are safe for us to use.
+		01/29/24 MAS	Added the 4-bit RadarGateCounter for timing
+				RADARUPT generation.
 
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -394,6 +396,7 @@ typedef struct
   unsigned Trap31A:1;           // Enable flag for Trap 31A
   unsigned Trap31B:1;           // Enable flag for Trap 31B
   unsigned Trap32:1;            // Enable flag for Trap 32
+  unsigned RadarGateCounter:4;  // Counter tracking radar cycle progress
   uint32_t WarningFilter;       // Current voltage of the AGC warning filter
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   int Downlink;
@@ -575,6 +578,7 @@ int ChannelInput (agc_t * State);
 void ChannelRoutine (agc_t *State);
 void ChannelRoutineGeneric (void *State, void (*UpdatePeripherals) (void *, Client_t *));
 void ShiftToDeda (agc_t *State, int Data);
+void RequestRadarData (agc_t *State);
 
 #endif // AGC_ENGINE_H
 

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -93,6 +93,7 @@
  * 		07/13/17 MAS	Added initialization of the three HANDRUPT traps.
  * 		05/13/21 MKF	Disabled UnblockSocket for the WASI target
  *  				(there are no sockets in wasi-libc)
+ * 		01/29/24 MAS	Added initialization of RadarGateCounter.
  */
 
 // For Orbiter.
@@ -315,6 +316,8 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->Trap31A = 0;
   State->Trap31B = 0;
   State->Trap32 = 0;
+
+  State->RadarGateCounter = 0;
 
   if (initializeSunburst37)
     {

--- a/yaAGC/ringbuffer_api.c
+++ b/yaAGC/ringbuffer_api.c
@@ -38,6 +38,9 @@
   Contact:   Michael Karl Franzl <public.michael@franzl.name>
   Reference: http://www.ibiblio.org/apollo/index.html
   Mods:      2020-06-07 MKF  Created.
+             2024-01-29 MAS  Added stub RequestRadarData function for use
+                             by integrators of yaAGC into spacecraft
+                             simulations.
 */
 
 #include "yaAGC.h"
@@ -184,5 +187,10 @@ ChannelRoutine (agc_t* State)
 
 void
 ShiftToDeda (agc_t* State, int Data)
+{
+}
+
+void
+RequestRadarData (agc_t *State)
 {
 }


### PR DESCRIPTION
RADARUPTs are somewhat unique in the AGC in that unlike other interrupts for external hardware, all of the timing for the interrupt and the actual generation of the interrupt occurs entirely within the AGC. Strictly speaking, no hardware even needs to be attached to the computer for a radar cycle to complete and a RADARUPT to be generated.

It turns out that certain ropes, especially Skylark, are very sensitive to the exact timing of this interrupt. If they appear too early or too late, it's possible to get program alarms, or even for running programs to silently break and become completely non-functional. As such, I think it makes sense to add accurate RADARUPT simulation to yaAGC.

The timing for the interrupt presented in this PR is as accurate as I can get it without deeper changes to yaAGC. The real conditions for RADARUPTs are:
1. RadarGateCounter == 9
2. F05B
3. ~FS06 && FS07 && FS08 && FS09 && FS10

yaAGC currently only increments its scaler at 3200Hz, but to see F05B we'd have to double it to 6400Hz. So instead I've placed it very slightly (~10 MCT) early, which shouldn't be have any bad effects.

I decided to implement the function that actually gets radar data as a callback for integrators like NASSP to provide their own implementation for. The existing fictitious channel stuff didn't seem applicable since fictitious input channels are processed asynchronously from the computer logic, and fictitious output values aren't going to return a value. Also, it didn't appear that there was currently any way at all for external users to actually generate RADARUPTs, so I went ahead and just made that always happen. If we want to provide for the possibility of it not happening, we can instead push some or all of the RADARUPT generation/side effect code into the callback. I'm open to other ways of doing this, though, if you have better ideas.

@indy91 has flown a Skylab rendezvous with Skylark using these changes, and they have greatly improved the experience (i.e. Skylark no longer totally breaks). He's also flown a landing and everything works as expected with the landing radar.