### PR TITLE
Add Alarm Messages

### DIFF
--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -2027,6 +2027,7 @@ agc_engine (agc_t * State)
                   State->SbyStillPressed = 1;
 
                   // While this isn't technically an alarm, it causes GOJAM just like all the rest
+                  printf("Alarm: Standby\n");
                   TriggeredAlarm = 1;
 
                   // Turn on the STBY light, and switch off the EL segments
@@ -2054,6 +2055,7 @@ agc_engine (agc_t * State)
           if (!State->Standby && State->NightWatchman)
             {
               // NEWJOB wasn't checked before 0.64s elapsed. Sound the alarm!
+              printf("Alarm: NightWatchman\n");
               TriggeredAlarm = 1;
 
               // Set the NIGHT WATCHMAN bit in channel 77. Don't go through CpuWriteIO() because
@@ -2102,6 +2104,7 @@ agc_engine (agc_t * State)
           else if ((State->RuptLock || State->NoRupt) && 0300 == (0777 & State->InputChannel[ChanSCALER1]))
             {
               // We've either had no interrupts, or stuck in one, for 140ms. Sound the alarm!
+              printf("Alarm: Rupt (%i %i)\n", State->RuptLock, State->NoRupt);
               TriggeredAlarm = 1;
 
               // Set the RUPT LOCK bit in channel 77.
@@ -2117,6 +2120,7 @@ agc_engine (agc_t * State)
           else if ((State->TCTrap || State->NoTC) && 000 == (037 & State->InputChannel[ChanSCALER1]))
             {
               // We've either executed no TC at all, or only TCs, for the past 5ms. Sound the alarm!
+              printf("Alarm: TC (%i %i)\n", State->TCTrap, State->NoTC);
               TriggeredAlarm = 1;
 
               // Set the TC TRAP bit in channel 77.


### PR DESCRIPTION
Prints messages when the master alarm is triggered, and indicates what the type of the alarm.

Several alarms are reboots are silently being triggered in [example code](https://www.ibiblio.org/apollo/DIY.html#Bare-Metal_Programming).  Raising visibility of them is a prerequisite in either fixing the example code, or else fixing the AGC if the alarms are not correctly firing.