### PR TITLE
Restore compatibility with wxWidgets 3.0

### DIFF
--- a/VirtualAGC/VirtualAGC.cpp
+++ b/VirtualAGC/VirtualAGC.cpp
@@ -3037,7 +3037,7 @@ VirtualAGC::FormTiling(void)
     int xScreen, yScreen, wScreen, hScreen;
     wxClientDisplayRect(&xScreen, &yScreen, &wScreen, &hScreen);
     printf("Display rect: %d %d %d %d\n", xScreen, yScreen, wScreen, hScreen);
-    printf("DPI scale factor: %g\n", this->GetDPIScaleFactor());
+    //printf("DPI scale factor: %g\n", this->GetDPIScaleFactor());
 
     xScreen += 5;
     yScreen += 5;


### PR DESCRIPTION
This one line requires wxWidgets 3.1.4
Removing it allows existing 3.0 installations to continue to work.

Raspberry Pi OS (5.10 Buster) doesn't seem to have an apt upgrade path for > 3 at the moment.

Given that this is just a debugging line, I think the costs outweigh the value.


```
VirtualAGC.cpp: In member function ‘bool VirtualAGC::FormTiling()’:
VirtualAGC.cpp:3040:44: error: ‘class VirtualAGC’ has no member named ‘GetDPIScaleFactor’; did you mean ‘GetContentScaleFactor’?
     printf("DPI scale factor: %g\n", this->GetDPIScaleFactor());
                                            ^~~~~~~~~~~~~~~~~
                                            GetContentScaleFactor
make[1]: *** [Makefile:215: VirtualAGC] Error 1
make[1]: Leaving directory '/home/pi/virtualagc/VirtualAGC'
make: *** [Makefile:610: VirtualAGC] Error 2
```
