### PR TITLE
CI: Windows: use only the preinstalled GCC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,30 +75,17 @@ jobs:
     - uses: ./.github/workflows/composite-unix
 
 
-  windows-gcc-clang:
+  windows-gcc:
     runs-on: windows-latest
     timeout-minutes: 10
 
-    strategy:
-      matrix:
-        comp: [{pkg: gcc, cxx: g++},
-               {pkg: clang, cxx: clang++}
-               ]
-
+    # this uses GCC preinstalled in the Windows runner
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md#tools
     env:
-      CC: ${{ matrix.comp.pkg }}
-      CXX: ${{ matrix.comp.cxx }}
+      CC: gcc
+      CXX: g++
 
     steps:
-    - uses: msys2/setup-msys2@v2
-      id: msys2
-      with:
-        update: true
-        install: mingw-w64-ucrt-x86_64-${{ matrix.comp.pkg }}
-
-    - name: Put MSYS2_MinGW64 on PATH
-      run: echo "${{ steps.msys2.outputs.msys2-location }}/ucrt64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
     - *checkout
 
     - run: cmake --workflow default


### PR DESCRIPTION
This avoids need for third-party actions as per https://github.com/virtualagc/virtualagc/pull/1264#issuecomment-3511456563