### PR TITLE
ASM101S: Remove empty merge conflict markers from parser_asm.py.

### DIFF
--- a/ASM101S/parser_asm.py
+++ b/ASM101S/parser_asm.py
@@ -1206,8 +1206,6 @@ class asmParser(Parser):
                 self._define(
                     [],
                     ['d', 'h', 'l', 't'],
-<<<<<<< HEAD
-=======
                 )
             with self._option():
                 with self._optional():
@@ -1232,7 +1230,6 @@ class asmParser(Parser):
                 self._define(
                     ['f', 'z'],
                     ['d', 't'],
->>>>>>> branch 'master' of https://github.com/virtualagc/virtualagc.git
                 )
             self._error(
                 'expecting one of: '


### PR DESCRIPTION
https://github.com/virtualagc/virtualagc/commit/f5b614f30bd6985d78fe5c3fabdec84234409193 added 'Z' handling to the ASM101S grammar and regenerated parser_asm.py

https://github.com/virtualagc/virtualagc/commit/d4bdf2b84aea0fac05c8412deeba79de3866ade6 attempted to merge an older parser_asm.py without 'Z' handling and generated a merge conflict, which was commited

The conflict was empty; just the added 'Z' handling code, so it's an easy fix to remove the markers

Warning: if there's a local tree with a regenerated parser_asm.py that will merge commits onto main it's likely this will happen again!
