### PR TITLE
yaYUL: fatal error when bugger word would overwrite user data

### DIFF
--- a/yaYUL/yaYUL.c
+++ b/yaYUL/yaYUL.c
@@ -549,16 +549,59 @@ main(int argc, char *argv[])
               Value = GetBankCount(Bank);
               if (Value > 0)
                 {
+                  // Before placing any auto-generated checksum infrastructure
+                  // (bank-id tags or bugger word), verify the target slot is
+                  // genuinely unused.  yaYUL initialises unused fixed memory
+                  // to data 0 with parity 0 — an invalid parity combination
+                  // (CalculateParity(0) == 1).  A user-written constant of
+                  // value zero, by contrast, gets parity 1 from the normal
+                  // emit path.  So (data==0 && parity==0) uniquely identifies
+                  // an untouched slot, distinguishing it from "user wrote 0".
+                  //
+                  // If the slot is already occupied, the bank is too full to
+                  // accept its bugger infrastructure.  This is a fatal error:
+                  // overwriting user data with the checksum would silently
+                  // corrupt the rope.  Until 2026 yaYUL did exactly that and
+                  // it caused some very hard-to-diagnose bugs.
+#define BUGGER_SLOT_FREE(b, v) \
+    (ObjectCode[(b)][(v)] == 0 && Parities[(b)][(v)] == 0)
+#define REPORT_BANK_FULL(b, v) do { \
+    int addr = (Block1 ? 06000 : 02000) + (v); \
+    printf("Fatal error: bank %02o is full; cannot insert " \
+           "automatic bugger-word infrastructure\n" \
+           "             at offset %04o without overwriting user data.\n", \
+           (b), addr); \
+    printf("             Either free at least one word in the bank, " \
+           "or assemble with --no-checksums\n" \
+           "             to disable bugger-word emission entirely.\n"); \
+    fprintf(stderr, "Fatal: bank %02o full at offset %04o; bugger word " \
+            "would overwrite user data.\n", (b), addr); \
+    if (HtmlOut != NULL) \
+        fprintf(HtmlOut, "Fatal error: bank %02o is full at offset %04o; " \
+                "no room for bugger word.\n", (b), addr); \
+    Fatals++; \
+} while (0)
+
                   if (!Block1 && !blk2)
                     {
                       if (Value < 01776)
                         {
+                          if (!BUGGER_SLOT_FREE(Bank, Value))
+                            {
+                              REPORT_BANK_FULL(Bank, Value);
+                              goto SkipBugger;
+                            }
                           ObjectCode[Bank][Value] = Value + Offset;
                           Parities[Bank][Value] = CalculateParity(Value + Offset);
                           Value++;
                         }
                       if (Value < 01777)
                         {
+                          if (!BUGGER_SLOT_FREE(Bank, Value))
+                            {
+                              REPORT_BANK_FULL(Bank, Value);
+                              goto SkipBugger;
+                            }
                           ObjectCode[Bank][Value] = Value + Offset;
                           Parities[Bank][Value] = CalculateParity(Value + Offset);
                           Value++;
@@ -566,6 +609,11 @@ main(int argc, char *argv[])
                     }
                   if (Value < 02000)
                     {
+                      if (!BUGGER_SLOT_FREE(Bank, Value))
+                        {
+                          REPORT_BANK_FULL(Bank, Value);
+                          goto SkipBugger;
+                        }
                       for (Bugger = Offset = 0; Offset < Value; Offset++) {
                         Bugger = Add(Bugger, ObjectCode[Bank][Offset]);
                       }
@@ -581,6 +629,9 @@ main(int argc, char *argv[])
                         fprintf(HtmlOut, "Bugger word %05o at %02o,%04o.\n",
                             GuessBugger, Bank, (Block1 ? 06000 : 02000) + Value);
                     }
+                SkipBugger: ;
+#undef BUGGER_SLOT_FREE
+#undef REPORT_BANK_FULL
                 }
             }
           // Output the binary data.
@@ -602,6 +653,18 @@ main(int argc, char *argv[])
               fputc(Value, OutputFile);
             }
         }
+      // If the bugger-word inserter raised any fatal errors above, the
+      // earlier "Fatal errors:" line is stale.  Re-emit a corrected total
+      // so the listing reflects reality (and the .bin will be removed
+      // below at the existing post-output cleanup).
+      static int StaleFatalsReported = 0;
+      if (Fatals > StaleFatalsReported)
+        {
+          printf("Fatal errors (final):  %d\n", Fatals);
+          if (HtmlOut != NULL)
+            fprintf(HtmlOut, "Fatal errors (final):  %d\n", Fatals);
+        }
+      StaleFatalsReported = Fatals;
     }
 
   // All done!


### PR DESCRIPTION
Addresses the bugger-word overwrite bug discussed in the linked issue.
Implements the parity-aware fatal-error approach @rburkey2005 suggested
in review.

## What this fixes

When a fixed-fixed bank is packed to exact capacity (1024 words),
yaYUL's automatic bugger-word inserter writes on top of whatever user
constants or instructions already occupy the last word(s) of the bank.
The corruption is silent — the listing still shows the user's intended
value at that address — and silently miscompiles the rope.

Real Apollo flight ropes aren't affected because they pin each block
to a bank with explicit `BANK` directives and reserve slots for the
bugger infrastructure. The bug only surfaces in programs that rely on
yaYUL's automatic packing.

## How it's fixed

Per the review feedback in the linked issue:

- **Parity check, not zero check.** `Pass.c:1551-1556` initializes
  unused fixed memory to `ObjectCode = 0, Parities = 0`, an invalid
  parity combination (`CalculateParity(0)` returns 1). User-written
  values — including `DEC 0` — always get a *valid* parity bit. So
  the predicate `(ObjectCode == 0 && Parities == 0)` is true iff the
  slot is genuinely untouched. This correctly distinguishes "never
  written" from "user wrote zero," addressing the concern that a real
  user zero shouldn't be clobbered either.
- **Fatal error, not warning.** When the predicate fails, yaYUL prints
  a clear error to both the listing and `stderr`, increments `Fatals`,
  skips the bugger infrastructure for that bank, and the existing
  post-output cleanup at `yaYUL.c:719` removes the `.bin`. Build exits
  with non-zero status.
- **Applied to all three potential auto-writes** in the bugger-emission
  block — the two bank-id tag words *and* the bugger word — since any
  of the three can collide with user data when a bank fills up.
- **Re-emits the final "Fatal errors" tally** after the bugger phase,
  since the existing tally line runs before the bugger phase and would
  otherwise stale at zero.

## Error message

When triggered, the listing receives:

```
Fatal error: bank 02 is full; cannot insert automatic bugger-word infrastructure
             at offset 3777 without overwriting user data.
             Either free at least one word in the bank, or assemble with --no-checksums
             to disable bugger-word emission entirely.
Fatal errors (final):  1
```

And stderr receives a one-liner so it surfaces even if stdout is
redirected to a `.lst` file:

```
Fatal: bank 02 full at offset 3777; bugger word would overwrite user data.
```

The wording deliberately tells the user *what* went wrong, *what* the
consequence would have been, and *how* to fix it — putting the
mitigation directly in the diagnostic so it doesn't need to be
documented elsewhere.

## Tested

| scenario | result |
|----------|--------|
| Minimal repro (CANARY at 5777, full bank, from the linked issue's demo) | Fatal error, `.bin` removed, exit 1 |
| Same repro with `--no-checksums` | Builds cleanly, `.bin` produced |
| Bank with one free word | Builds cleanly, bugger lands in the free slot |
| Bank packed full with a workaround filler (`OCT 0` in user code) | Correctly diagnosed as fatal — the filler workaround is no longer needed |
| **Luminary099** (Apollo 11 LM rope) | `.bin` is **byte-identical** to the unpatched assembler (SHA-256 `1f5326e038de5b741b2f27b01ec949dbd688cf1906994e997402587c8628f40e`) |

No behavior change for any rope that doesn't pack a fixed-fixed bank
to exact capacity — i.e., zero impact on any historical Apollo
reconstruction.

## Diff size

63 lines added to a single file (`yaYUL/yaYUL.c`). No other files
touched. Detailed rationale in the commit message.

## Note on `UpdateBankCounts`

The linked issue's original write-up also proposed an off-by-one fix
to `UpdateBankCounts` in `ParseBANK.c`. I left that alone here — the
parity check catches the actual corruption regardless of whether bank
counts are accurate, and the parity check is more robust (it would
catch a corruption attempt arising from any miscounting bug, not just
the specific boundary case identified). 