### PR TITLE
yaShuttle: HAL/S examples: changes for testability

### DIFF
--- a/yaShuttle/Source Code/Programming in HAL-S/037-ROOTS.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/037-ROOTS.hal
@@ -5,14 +5,14 @@ C/ polynomial using the roots, and to allow complex roots.
 
   ROOTS: PROGRAM;
     DECLARE SCALAR, A, B, C, D, ROOT1, ROOT2;
-    DO WHILE TRUE;
+    ROOTLOOP: DO WHILE TRUE;
         WRITE(6) ;
         WRITE(6) 'Enter A, B, C (0,0,0 to quit):';
         READ(5) A, B, C;
         IF A = 0 AND B = 0 AND C = 0 THEN
             DO;
                 WRITE(6) 'Quitting ...';
-                EXIT;
+                EXIT ROOTLOOP;
             END;
         D = B**2 - 4 A C;
         IF D >= 0 THEN 

--- a/yaShuttle/Source Code/Programming in HAL-S/129-ALMOST_EQUAL.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/129-ALMOST_EQUAL.hal
@@ -1,4 +1,6 @@
-C/ From PDF p. 129 of "Progamming in HAL/S".
+C/ From PDF p. 129 of "Programming in HAL/S".
+
+  TEST_ALMOST_EQUAL: PROGRAM;
 
   ALMOST_EQUAL:
   FUNCTION(A, B) BOOLEAN;
@@ -13,6 +15,16 @@ C/ From PDF p. 129 of "Progamming in HAL/S".
         RETURN FALSE;
      ELSE
         RETURN TRUE;
-Y %SVCI(0);
   CLOSE ALMOST_EQUAL;
-  
+
+    WRITE(6) 'AE(1,1)=', ALMOST_EQUAL(1.0, 1.0);
+    WRITE(6) 'AE(1,1+1E-7)=', ALMOST_EQUAL(1.0, 1.0000001);
+    WRITE(6) 'AE(1,1.01)=', ALMOST_EQUAL(1.0, 1.01);
+    WRITE(6) 'AE(0,0)=', ALMOST_EQUAL(0.0, 0.0);
+    WRITE(6) 'AE(0,1E-7)=', ALMOST_EQUAL(0.0, 0.0000001);
+    WRITE(6) 'AE(1E6,1E6+.5)=', ALMOST_EQUAL(1E6, 1000000.5);
+    WRITE(6) 'AE(-5,-5)=', ALMOST_EQUAL(-5.0, -5.0);
+    WRITE(6) 'AE(1,-1)=', ALMOST_EQUAL(1.0, -1.0);
+
+Y %SVCI(0);
+  CLOSE TEST_ALMOST_EQUAL;

--- a/yaShuttle/Source Code/Programming in HAL-S/134-DOTS.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/134-DOTS.hal
@@ -1,4 +1,14 @@
 C/ From PDF p. 134 of "Programming in HAL/S".
+C/ DOTS computes a 10x10 matrix of dot products from two
+C/ arrays of 10 3-vectors each: RESULT(I,J) = A1(I) . A2(J).
+
+  TEST_DOTS: PROGRAM;
+C  V1(I)=(I,0,0), V2(J)=(1,0,0) => RESULT(I,J)=I
+    DECLARE ARRAY(10) VECTOR(3),
+        V1 INITIAL(1,0,0, 2,0,0, 3,0,0, 4,0,0, 5,0,0,
+                   6,0,0, 7,0,0, 8,0,0, 9,0,0, 10,0,0),
+        V2 INITIAL(1,0,0, 1,0,0, 1,0,0, 1,0,0, 1,0,0,
+                   1,0,0, 1,0,0, 1,0,0, 1,0,0, 1,0,0);
 
   DOTS:
   FUNCTION(A1, A2) MATRIX(10, 10);
@@ -15,5 +25,9 @@ S               I,J     I:     J:
      END;
 E             *
 M    RETURN RESULT;
-Y %SVCI(0);
   CLOSE DOTS;
+
+    WRITE(6) 'DOTS:', DOTS(V1, V2);
+
+Y %SVCI(0);
+  CLOSE TEST_DOTS;

--- a/yaShuttle/Source Code/Programming in HAL-S/134-ROLL.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/134-ROLL.hal
@@ -1,7 +1,15 @@
 C/ From PDF p. 134 of "Programming in HAL/S."
 
+  TEST_ROLL: PROGRAM;
+
   ROLL:
   FUNCTION INTEGER;
      RETURN 5 RANDOM + 1;
   CLOSE ROLL;
-  
+
+    DO FOR TEMPORARY I = 1 TO 5;
+      WRITE(6) 'ROLL=', ROLL;
+    END;
+
+Y %SVCI(0);
+  CLOSE TEST_ROLL;

--- a/yaShuttle/Source Code/Programming in HAL-S/136-DOTS.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/136-DOTS.hal
@@ -1,4 +1,13 @@
 C/ From PDF p. 136 of "Programming in HAL/S".
+C/ Same as 134-DOTS but as a PROCEDURE with ASSIGN.
+
+  TEST_DOTS: PROGRAM;
+    DECLARE ARRAY(10) VECTOR(3),
+        V1 INITIAL(1,0,0, 2,0,0, 3,0,0, 4,0,0, 5,0,0,
+                   6,0,0, 7,0,0, 8,0,0, 9,0,0, 10,0,0),
+        V2 INITIAL(1,0,0, 1,0,0, 1,0,0, 1,0,0, 1,0,0,
+                   1,0,0, 1,0,0, 1,0,0, 1,0,0, 1,0,0);
+    DECLARE R MATRIX(10, 10);
 
   DOTS:
   PROCEDURE(A1, A2) ASSIGN(RESULT);
@@ -14,4 +23,9 @@ S               I,J     I:     J:
         END;
      END;
   CLOSE DOTS;
-  
+
+    CALL DOTS(V1, V2) ASSIGN(R);
+    WRITE(6) 'DOTS:', R;
+
+Y %SVCI(0);
+  CLOSE TEST_DOTS;

--- a/yaShuttle/Source Code/Programming in HAL-S/137-STATISTICS.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/137-STATISTICS.hal
@@ -1,6 +1,10 @@
-C/ From PDF p. 137 of "Programming in HAL/S".  Surrounding brackets 
-C/ have been removed from array variables, since they are not legal 
+C/ From PDF p. 137 of "Programming in HAL/S".  Surrounding brackets
+C/ have been removed from array variables, since they are not legal
 C/ HAL/S syntax.
+
+  TEST_STATS: PROGRAM;
+    DECLARE DATA ARRAY(100) SCALAR;
+    DECLARE SCALAR, LO, HI, MN;
 
   STATISTICS:
   PROCEDURE(DATA) ASSIGN(LO_VAL, HI_VAL, MEAN);
@@ -10,6 +14,13 @@ C/ HAL/S syntax.
      LO_VAL = MIN(DATA);
      HI_VAL = MAX(DATA);
      MEAN = SUM(DATA) / 100;
-Y %SVCI(0);
   CLOSE STATISTICS;
-  
+
+    DO FOR TEMPORARY I = 1 TO 100;
+      DATA$(I) = I;
+    END;
+    CALL STATISTICS(DATA) ASSIGN(LO, HI, MN);
+    WRITE(6) 'LO=', LO, 'HI=', HI, 'MEAN=', MN;
+
+Y %SVCI(0);
+  CLOSE TEST_STATS;

--- a/yaShuttle/Source Code/Programming in HAL-S/138-FILTER.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/138-FILTER.hal
@@ -1,6 +1,10 @@
-C/ From PDF p. 138 of "Programming in HAL/S".  Surrounding brackets 
-C/ have been removed from array variables, since they are not legal 
+C/ From PDF p. 138 of "Programming in HAL/S".  Surrounding brackets
+C/ have been removed from array variables, since they are not legal
 C/ HAL/S syntax.
+
+  TEST_FILTER: PROGRAM;
+    DECLARE SCALAR, VAL, AVG;
+    DECLARE BUF ARRAY(4) SCALAR INITIAL(0, 0, 0, 0);
 
   FILTER:
   PROCEDURE(INPUT) ASSIGN(AUG_LAST4, BUFF);
@@ -14,5 +18,13 @@ M    BUFF  = INPUT;
 S        4
 
      AUG_LAST4 = SUM(BUFF) / 4;
-Y %SVCI(0);
   CLOSE FILTER;
+
+    DO FOR TEMPORARY I = 1 TO 6;
+      VAL = 10 I;
+      CALL FILTER(VAL) ASSIGN(AVG, BUF);
+      WRITE(6) 'IN=', VAL, 'AVG=', AVG;
+    END;
+
+Y %SVCI(0);
+  CLOSE TEST_FILTER;

--- a/yaShuttle/Source Code/Programming in HAL-S/140-STATISTICS.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/140-STATISTICS.hal
@@ -1,6 +1,12 @@
-C/ From PDF p. 140 of "Programming in HAL/S".  Surrounding brackets 
-C/ have been removed from array variables, since they are not legal 
+C/ From PDF p. 140 of "Programming in HAL/S".  Surrounding brackets
+C/ have been removed from array variables, since they are not legal
 C/ HAL/S syntax.
+C/ Same as 137 but with ARRAY(*) for variable-length arrays.
+
+  TEST_STATS: PROGRAM;
+    DECLARE DATA ARRAY(5) SCALAR
+        INITIAL(10, 20, 30, 40, 50);
+    DECLARE SCALAR, LO, HI, MN;
 
   STATISTICS:
   PROCEDURE(DATA) ASSIGN(LO_VAL, HI_VAL, MEAN);
@@ -10,5 +16,10 @@ C/ HAL/S syntax.
      LO_VAL = MIN(DATA);
      HI_VAL = MAX(DATA);
      MEAN = SUM(DATA) / SIZE(DATA);
-Y %SVCI(0);
   CLOSE STATISTICS;
+
+    CALL STATISTICS(DATA) ASSIGN(LO, HI, MN);
+    WRITE(6) 'LO=', LO, 'HI=', HI, 'MEAN=', MN;
+
+Y %SVCI(0);
+  CLOSE TEST_STATS;

--- a/yaShuttle/Source Code/Programming in HAL-S/141-VSUM.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/141-VSUM.hal
@@ -1,6 +1,10 @@
 C/ From PDF p. 141 of "Programming in HAL/S".  Surrounding brackets
-C/ have been removed from array variables, since they are not legal 
+C/ have been removed from array variables, since they are not legal
 C/ HAL/S syntax.
+
+  TEST_VSUM: PROGRAM;
+    DECLARE ARRAY(3) VECTOR(3),
+        V INITIAL(1,0,0, 0,2,0, 0,0,3);
 
   VSUM:
   FUNCTION(V) VECTOR;
@@ -15,6 +19,9 @@ S                        N:
      END;
 E             -
 M    RETURN TOTAL;
-Y %SVCI(0);
   CLOSE VSUM;
-  
+
+    WRITE(6) 'SUM=', VSUM(V);
+
+Y %SVCI(0);
+  CLOSE TEST_VSUM;

--- a/yaShuttle/Source Code/Programming in HAL-S/158-STATE.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/158-STATE.hal
@@ -1,12 +1,14 @@
 C/ From PDF p. 158 of "Programming in HAL/S".
 
+  TEST_STATE: PROGRAM;
+
   STATE:
   FUNCTION(B, TYPE) CHARACTER(5);
      DECLARE B BOOLEAN,
                 TYPE INTEGER;
-     DECLARE YES ARRAY(4) CHARACTER(5) 
+     DECLARE YES ARRAY(4) CHARACTER(5)
                          INITIAL('TRUE', 'ON', 'OPEN', 'VALID');
-     DECLARE NO ARRAY(4) CHARACTER(5) 
+     DECLARE NO ARRAY(4) CHARACTER(5)
                          INITIAL('FALSE', 'OFF', 'SHUT', 'ERROR');
 E       .
 M    IF B THEN
@@ -19,6 +21,12 @@ E              ,
 M       RETURN NO     ;
 S                TYPE:
 
-Y %SVCI(0);
   CLOSE STATE;
-  
+
+    WRITE(6) STATE(TRUE, 1), STATE(FALSE, 1);
+    WRITE(6) STATE(TRUE, 2), STATE(FALSE, 2);
+    WRITE(6) STATE(TRUE, 3), STATE(FALSE, 3);
+    WRITE(6) STATE(TRUE, 4), STATE(FALSE, 4);
+
+Y %SVCI(0);
+  CLOSE TEST_STATE;

--- a/yaShuttle/Source Code/Programming in HAL-S/160-REFORMAT.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/160-REFORMAT.hal
@@ -1,11 +1,13 @@
 C/ From PDF p. 160 of "Programming in HAL/S".
 
+  TEST_REFORMAT: PROGRAM;
+
   REFORMAT:
   FUNCTION(X, DECIMALS, WIDTH) CHARACTER(20);
      DECLARE X SCALAR,
              DECIMALS INTEGER,
              WIDTH INTEGER;
-             
+
 C  X IS THE NUMBER TO BE CONVERTED, DECIMALS IS THE NUMBER OF
 C  DIGITS TO BE PRINTED AFTER THE DECIMAL POINT, AND WIDTH IS
 C  THE TOTAL LENGTH OF THE STRING RETURNED
@@ -40,6 +42,11 @@ E              ,    ,                        ,
 M RETURN RJUST(S || C                || '.'||C                 , WIDTH);
 S                    1 TO #-DECIMALS          #-DECIMALS-1 TO #
 
-Y %SVCI(0);
   CLOSE REFORMAT;
-  
+
+    WRITE(6) REFORMAT(3.14159, 2, 10);
+    WRITE(6) REFORMAT(-42.5, 1, 10);
+    WRITE(6) REFORMAT(0.007, 3, 10);
+
+Y %SVCI(0);
+  CLOSE TEST_REFORMAT;

--- a/yaShuttle/Source Code/Programming in HAL-S/176-P.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/176-P.hal
@@ -1,20 +1,10 @@
 C/ Adapted from PDF p. 176 of "Programming in HAL/S".
-
-C/ Normally, if READ_ACC() were really a function in a separate 
-C/ compilation unit, its template and that of SUPER_VECTOR (its return
-C/ type) would be read in from the template library with a 
-C/ "D INCLUDE TEMPLATE compoolname" directive.  In this case,
-C/ though, there's no such function, and the following lines mimic
-C/ what could be in such an included template, without having to 
-C/ actually create any such function.  Of course, that means
-C/ that while this sample file can be compiled, the object code could
-C/ not be executed without actually supplying a READ_ACC() function too.
-  DUMMY_COMPOOL: EXTERNAL COMPOOL;
-     STRUCTURE SUPER_VECTOR:
-        1 V VECTOR,
-        1 STATUS BOOLEAN,
-        1 TIMETAG SCALAR;
-  CLOSE DUMMY_COMPOOL;
+C/
+C/ The SUPER_VECTOR template and READ_ACC function are supplied
+C/ externally (176.0-SUPER_VECTOR.hal and 176.1-READ_ACC.hal).
+C/ The template is loaded from the template library; READ_ACC is
+C/ linked in from its separately compiled object file.
+D INCLUDE TEMPLATE DUMMY_COMPOOL
   READ_ACC: EXTERNAL FUNCTION(N) SUPER_VECTOR-STRUCTURE;
      DECLARE N INTEGER;
   CLOSE READ_ACC;
@@ -42,7 +32,15 @@ C  ASSUME THAT 17 SELECTS THE CORRECT ACCELEROMETER
      CALL INTEGRATE(STATE2.STATE.VELOCITY) 
                                         ASSIGN(STATE2.STATE.POSITION);
      CYCLE = CYCLE + 1;
-     FILE(TEST_DATA, CYCLE) = STATE2.STATE; /*SAVE FOR POST PROCESSING*/
+C  USA-003090/p.80 sect.6.4 File I/O:
+C     File I/O is not supported by the HAL/S-FC runtime library. If a FILE I/O 
+C     statement is compiled, unresolved external references will occur at link 
+C     edit time.
+C    FILE(TEST_DATA, CYCLE) = STATE2.STATE; /*SAVE FOR POST PROCESSING*/
+     WRITE(6) 'ACCEL=', STATE2.STATE.ACCEL.V;
+     WRITE(6) 'VEL=', STATE2.STATE.VELOCITY.V;
+     WRITE(6) 'POS=', STATE2.STATE.POSITION.V;
+     WRITE(6) 'CYCLE=', CYCLE;
   INTEGRATE:
   PROCEDURE(INPUT) ASSIGN(OUTPUT);
      DECLARE SUPER_VECTOR-STRUCTURE,

--- a/yaShuttle/Source Code/Programming in HAL-S/176.0-SUPER_VECTOR.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/176.0-SUPER_VECTOR.hal
@@ -1,0 +1,10 @@
+C/ COMPOOL defining the SUPER_VECTOR structure template used by
+C/ 176-P.hal and 176.1-READ_ACC.hal.  Compile with TEMPLATE parm
+C/ to add to template library.
+
+ DUMMY_COMPOOL: COMPOOL;
+    STRUCTURE SUPER_VECTOR:
+       1 V VECTOR,
+       1 STATUS BOOLEAN,
+       1 TIMETAG SCALAR;
+ CLOSE DUMMY_COMPOOL;

--- a/yaShuttle/Source Code/Programming in HAL-S/176.1-READ_ACC.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/176.1-READ_ACC.hal
@@ -1,0 +1,14 @@
+C/ External function for 176-P: simulates an accelerometer reading.
+C/ Returns a SUPER_VECTOR-STRUCTURE with a sample acceleration
+C/ vector, STATUS=TRUE, and a timetag derived from the selector N.
+D INCLUDE TEMPLATE DUMMY_COMPOOL
+
+  READ_ACC:
+  FUNCTION(N) SUPER_VECTOR-STRUCTURE;
+     DECLARE N INTEGER;
+     DECLARE RESULT SUPER_VECTOR-STRUCTURE;
+     RESULT.V = VECTOR(0.1, -0.2, 9.8);
+     RESULT.STATUS = TRUE;
+     RESULT.TIMETAG = N;
+     RETURN RESULT;
+  CLOSE READ_ACC;

--- a/yaShuttle/Source Code/Programming in HAL-S/205-LOG10.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/205-LOG10.hal
@@ -1,5 +1,7 @@
 C/ From PDF p. 205 in "Programming in HAL/S".
 
+  TEST_LOG10: PROGRAM;
+
   LOG10:
   FUNCTION(X) SCALAR;
      DECLARE X SCALAR;
@@ -9,8 +11,14 @@ C/ From PDF p. 205 in "Programming in HAL/S".
         DO;
 Z          SEND ERROR$(9:1);
            RETURN LOG(ABS(X)) / LOG(10);
-           
+
         END;
-Y %SVCI(0);
   CLOSE LOG10;
-  
+
+    WRITE(6) 'LOG10(1)=', LOG10(1.0);
+    WRITE(6) 'LOG10(10)=', LOG10(10.0);
+    WRITE(6) 'LOG10(100)=', LOG10(100.0);
+    WRITE(6) 'LOG10(0.5)=', LOG10(0.5);
+
+Y %SVCI(0);
+  CLOSE TEST_LOG10;

--- a/yaShuttle/Source Code/Programming in HAL-S/211-LIMIT.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/211-LIMIT.hal
@@ -1,5 +1,7 @@
 C/ Adapted from PDF p. 211 of "Programming in HAL/S".
 
+  TEST_LIMIT: PROGRAM;
+
      LIMIT:
      FUNCTION(VALUE, BOUND) SCALAR;
         DECLARE SCALAR,
@@ -9,5 +11,12 @@ C/ Adapted from PDF p. 211 of "Programming in HAL/S".
         IF VALUE < -BOUND THEN
            RETURN -BOUND;
         RETURN VALUE;
-Y %SVCI(0);
      CLOSE LIMIT;
+
+    WRITE(6) 'LIMIT(5,10)=', LIMIT(5.0, 10.0);
+    WRITE(6) 'LIMIT(15,10)=', LIMIT(15.0, 10.0);
+    WRITE(6) 'LIMIT(-15,10)=', LIMIT(-15.0, 10.0);
+    WRITE(6) 'LIMIT(0,1)=', LIMIT(0.0, 1.0);
+
+Y %SVCI(0);
+  CLOSE TEST_LIMIT;

--- a/yaShuttle/Source Code/Programming in HAL-S/225-MEAN.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/225-MEAN.hal
@@ -1,6 +1,10 @@
 C/ From PDF p. 225 in "Programming in HAL/S".  Surrounding brackets
-C/ have been removed from array variables, since they are not legal 
+C/ have been removed from array variables, since they are not legal
 C/ HAL/S syntax.
+
+  TEST_MEAN: PROGRAM;
+
+     DECLARE DATA ARRAY(5) SCALAR INITIAL(1.0, 2.0, 3.0, 4.0, 5.0);
 
   MEAN:
 Y FUNCTION(A) SCALAR;
@@ -13,6 +17,9 @@ S                        I
 
      END;
      RETURN TOTAL / SIZE(A);
-Y %SVCI(0);
   CLOSE MEAN;
-  
+
+    WRITE(6) 'MEAN(1..5)=', MEAN(DATA);
+
+Y %SVCI(0);
+  CLOSE TEST_MEAN;

--- a/yaShuttle/Source Code/Programming in HAL-S/253-TEST0.hal
+++ b/yaShuttle/Source Code/Programming in HAL-S/253-TEST0.hal
@@ -1,19 +1,27 @@
 C/ Adapted from PDF p. 253 of "Programming in HAL/S".
 
+  TEST_TEST: PROGRAM;
+
   TEST:
   FUNCTION(I) BOOLEAN;
      DECLARE I INTEGER;
      DECLARE INTEGER,
                 WORD, BITNUM;
-     DECLARE INFO ARRAY(1 + 1000 / 16) BIT(16) 
+     DECLARE INFO ARRAY(1 + 1000 / 16) BIT(16)
                                         INITIAL(BIN'11010111101');
-     
+
      WORD = DIV(I, 16);
      BITNUM = I - 16 WORD;
 E            .
 M    RETURN INFO               ;
 S               WORD+1:BITNUM+1
- 
-Y %SVCI(0);
+
   CLOSE TEST;
-  
+
+    WRITE(6) 'TEST(0)=', TEST(0);
+    WRITE(6) 'TEST(1)=', TEST(1);
+    WRITE(6) 'TEST(2)=', TEST(2);
+    WRITE(6) 'TEST(5)=', TEST(5);
+
+Y %SVCI(0);
+  CLOSE TEST_TEST;


### PR DESCRIPTION
Some additions to the HAL/S example programs in `yaShuttle/Source Code/Programming in HAL-S/` that makes them more useful as test cases:
  - Add driver programs to call bare functions
  - Add suitable test inputs where there weren't any supplied
  - Write results to default output
  - Implement external COMPOOL and function for `176-P.hal`
    - Exercises compool->template functionality and external references
  - Comment out `FILE()` call in `176-P.hal`
    - per USA-003090/p.80 sect.6.4 "File I/O" this is illegal
  - `037-ROOTS.hal`: convert to labeled `EXIT ROOTLOOP`
    - A bare `EXIT` breaks out of the innermost loop only.
    - An`EXIT LABEL` breaks out of all loops up to `LABEL:` and is required here. 

I pull these tests into [nsts-sdl-dps](https://github.com/ColanderCombo/nsts-sdl-dps) and compare against baselines that live here: [baselines](https://github.com/ColanderCombo/nsts-sdl-dps/tree/master/test/baselines)