### PR TITLE
Fix yaTelemetry SIGILL crash on macOS with --software (#1277)

### DIFF
--- a/yaAGC/DecodeDigitalDownlink.c
+++ b/yaAGC/DecodeDigitalDownlink.c
@@ -803,7 +803,7 @@ dddConfigure (char *agcSoftware, const char *docPrefix)
   for (int j = 0; j < numTsvFiles && j < MAX_DOWNLISTS; j++)
     {
       int id;
-      char filename[64];
+      char filename[SWIDTH + 1];
       DownlinkListSpec_t *dls;
       FieldSpec_t *fieldSpec;
       FILE *fp;

--- a/yaAGC/DecodeDigitalDownlink.c
+++ b/yaAGC/DecodeDigitalDownlink.c
@@ -819,7 +819,7 @@ dddConfigure (char *agcSoftware, const char *docPrefix)
       dls->id = id;
       if (aliasDoc[0] != 0)
 	{
-	  sprintf(dls->URL, "%s%s/ddd-%05o-%s.html", docPrefix, aliasDoc, id, aliasDoc);
+	  snprintf(dls->URL, sizeof(dls->URL), "%s%s/ddd-%05o-%s.html", docPrefix, aliasDoc, id, aliasDoc);
 	  //fprintf(stderr, "***DEBUG*** trying %s\n", dls->URL);
 	  // Test if the chosen file exists.
 	  aliases = fopen(&(dls->URL[7]), "r");
@@ -839,10 +839,10 @@ dddConfigure (char *agcSoftware, const char *docPrefix)
       if (dls->URL[0] == 0)
 	{
 	  if (!useFallbackDocumentation)
-	    sprintf(dls->URL, "%sddd-no-documentation.html", docPrefix);
+	    snprintf(dls->URL, sizeof(dls->URL), "%sddd-no-documentation.html", docPrefix);
 	  else if (CmOrLm)
 	    {
-	      sprintf(filename, "%sddd-%05o-unavailable-CM.html", docPrefix, id);
+	      snprintf(filename, sizeof(filename), "%sddd-%05o-unavailable-CM.html", docPrefix, id);
 	      fp = fopen(&filename[7], "r");
 	      if (fp != NULL)
 		{
@@ -850,11 +850,11 @@ dddConfigure (char *agcSoftware, const char *docPrefix)
 		  strcpy(dls->URL, filename);
 		}
 	      else
-		sprintf(dls->URL, "%sddd-unavailable-CM.html", docPrefix);
+		snprintf(dls->URL, sizeof(dls->URL), "%sddd-unavailable-CM.html", docPrefix);
 	    }
 	  else if (!Sundance)
 	    {
-	      sprintf(filename, "%sddd-%05o-unavailable-LM.html", docPrefix, id);
+	      snprintf(filename, sizeof(filename), "%sddd-%05o-unavailable-LM.html", docPrefix, id);
 	      //fprintf(stderr, "Checking for %s\n", filename);
 	      fp = fopen(&filename[7], "r");
 	      if (fp != NULL)
@@ -866,11 +866,11 @@ dddConfigure (char *agcSoftware, const char *docPrefix)
 	      else
 		{
 		  //fprintf(stderr, "Not found\n");
-		  sprintf(dls->URL, "%sddd-unavailable-LM.html", docPrefix);
+		  snprintf(dls->URL, sizeof(dls->URL), "%sddd-unavailable-LM.html", docPrefix);
 		}
 	    }
 	  else
-	    sprintf(dls->URL, "%sddd-unavailable.html", docPrefix);
+	    snprintf(dls->URL, sizeof(dls->URL), "%sddd-unavailable.html", docPrefix);
 	}
       sprintf(filename, "ddd-%05o-%s.tsv", id, aliasTsv);
       fp = fopen(filename, "rt");


### PR DESCRIPTION
Fixes #1277.

## Root cause

yaTelemetry crashes on macOS with "illegal hardware instruction" (SIGILL)
whenever `--software=...` is passed. It is a stack buffer overflow in
`dddConfigure()` in `yaAGC/DecodeDigitalDownlink.c`, not a shell issue.

A local `char filename[64]` receives:

```c
sprintf(filename, "%sddd-%05o-unavailable-LM.html", docPrefix, id);
```

On macOS `docPrefix` is the absolute app-bundle path
(`file:///.../VirtualAGC.app/Contents/Resources/documentation/`, about 80
characters), so this write overruns the 64-byte buffer, corrupts the stack,
and the process traps with SIGILL. It only triggers with `--software`
because that is the only path that runs `dddConfigure()`; bash vs zsh just
shifts the stack layout enough to mask or expose the corruption.

## Fix

Two small commits:

1. Size `filename` to `SWIDTH + 1` to match `dls->URL` (which it is copied
   into). This alone stops the crash.
2. Bind the `docPrefix` path builds with `snprintf` so no length of install
   path can overflow `dls->URL` or `filename`.

Eight lines changed, no behavior change for normal paths.

## Testing

- Isolated call to `dddConfigure("Luminary099", <80-char docPrefix>)` built
  with `-fstack-protector-all`: old code exits 132 (SIGILL), fixed code
  exits 0.
- Built the real yaTelemetry (wxWidgets 3.3, Apple clang) and ran the exact
  failing command from a long path:
  `yaTelemetry --simple --x=803 --y=30 --port=19800 --spacecraft=LM --software=Luminary099`
  The window opens, all six Luminary099 downlists load, and there is no
  crash.

Note: I built with Apple clang + wxWidgets 3.3 rather than the project's
IMCROSS macOS toolchain, so a maintainer build check is worthwhile. The
change itself is plain C buffer sizing.
