### PR TITLE
XCOM-I + patch optimization related fixes

### DIFF
--- a/XCOM-I/DECLARE.py
+++ b/XCOM-I/DECLARE.py
@@ -8,6 +8,7 @@ Purpose:    This is the module of XCOM-I.py which processes XPL
             DECLARE, ARRAY, or BASED statements.
 Reference:  http://www.ibibio.org/apollo/Shuttle.html
 Mods:       2024-03-07 RSB  Began experimenting with this concept.
+            2026-08-03 DAS  Allow '(' in INITIAL expressions.
 '''
 
 import copy
@@ -247,7 +248,7 @@ def DECLARE(pseudoStatement, scope, library, inRecord = False):
                 for token in attributes:
                     if skip > 0:
                         skip -= 1
-                    elif token == "(": # and inFirst:
+                    elif token == "(" and not inInitial:
                         inTop = True
                         topString = ''
                     elif inTop:

--- a/XCOM-I/generateC.py
+++ b/XCOM-I/generateC.py
@@ -15,7 +15,9 @@ Mods:       2024-03-27 RSB  Began.
             2026-02-19 RSB  Switched from left-to-right processing order in
                             in multipl assignments to right-to-left.
             2026-08-03 DAS  use runtime record widths set by SET_RECORD_WIDTH
-                            on RECORD DYNAMIC tables
+                            on RECORD DYNAMIC tables.
+                            Fix "BI002 ... NON COMMON RECORD AT LINK" error
+                            with otherwise persistent global records.
 '''
 
 import sys
@@ -770,12 +772,32 @@ def sortJumps(scope, extra = None):
 def generateADDR(scope, parameter):
     token = parameter["token"]
     if "builtin" in token and token["builtin"] == "DESCRIPTOR":
-        # SPACELIB uses the address of `DESCRIPTOR` to detect the upper
-        # boundary of `COMMON`.  Before I realized that, I chose to arrange
-        # memory somewhat differently, and to implement `DESCRIPTOR` as a 
-        # function rather than a variable.  The following is a workaround for
-        # that, in lieu of altering the design.
-        return regions[1][1]
+        # SPACELIB's space manager uses `ADDR(DESCRIPTOR)` solely as the upper
+        # boundary of "common" (persistent) based-record dope vectors:
+        #   _IS_COMMON(x) _AS '(x < ADDR(DESCRIPTOR))'
+        # In RECORD_LINK this asserts that every dope vector still on the
+        # FIRSTRECORD chain at link time lives in persistent storage (i.e. was
+        # not a transient record leaked past the end of the pass).
+        #
+        # In the original 360 build, `DESCRIPTOR` sat just above the COMMON
+        # region, so the persistent global based-record dope vectors fell below
+        # it.  Returning `regions[1][1]` (the end of XPL-`COMMON`, region 1)
+        # reproduced that *only* when the chain held nothing but explicitly
+        # COMMON-declared records: HAL/S-FC's persistent global based records
+        # (OUTER_REF_TABLE, MACRO_TEXTS, LINK_SORT, ...) are NOT declared
+        # COMMON, so XCOM-I allocates their dope vectors in the non-common
+        # static region (region 2, above `regions[1][1]`).  Any data-heavy
+        # compool that allocates one of them therefore tripped the assert and
+        # aborted PASS1 with "BI002 ... NON COMMON RECORD AT LINK" -- a false
+        # positive, since those records are genuinely persistent.
+        #
+        # In XCOM-I's flat model *every* based-record dope vector is allocated
+        # statically below `freeBase` (the dynamic free-string heap starts at
+        # `freeBase`); there are no transient dope vectors above it for the
+        # assert to catch.  So the correct boundary -- "is this dope vector in
+        # static/persistent memory" -- is `freeBase`, which makes _IS_COMMON
+        # true for all real dope vectors and the assert a (correct) no-op.
+        return freeBase
     elif "builtin" in token:
         # I allow this because there's some stuff in HAL/S-FC source code that
         # attempts various memory-management operations by exploiting hidden

--- a/XCOM-I/generateC.py
+++ b/XCOM-I/generateC.py
@@ -14,6 +14,8 @@ Mods:       2024-03-27 RSB  Began.
                             code upon error.
             2026-02-19 RSB  Switched from left-to-right processing order in
                             in multipl assignments to right-to-left.
+            2026-08-03 DAS  use runtime record widths set by SET_RECORD_WIDTH
+                            on RECORD DYNAMIC tables
 '''
 
 import sys
@@ -1213,6 +1215,29 @@ def getIdentifier(token):
         return token["builtin"]
     errxit("Token is neither an `identifier` nor a `builtin`: %s", str(token))
 
+# For a `BASED ... RECORD DYNAMIC` variable, the row width can be changed at
+# runtime by SET_RECORD_WIDTH (HALINCL/SPACELIB.xpl:70) so the stride used
+# for indexing records must be read at runtime rather than frozen at
+# translation time. Specifically, SPACELIB.xpl defines:
+#   _DOPE_WIDTH(1) _AS 'COREHALFWORD(%1%+4)',
+#   SET_RECORD_WIDTH(2) _AS  '_DOPE_WIDTH(ADDR(%1%))=%2%'
+# So to get the record width:
+#   COREHALFWORD(ADDR(x)+4)
+#
+# (ex: OPT.PROCS/INITIALI.xpl:123 sets PAR_SYM's row width to 2*(SYT_SIZE+1)
+#  via SET_RECORD_WIDTH; using the static one-element stride made all
+#  rows alias, destroying the CSE catalog on every PUSH_STACK.)
+#
+# Returns the C source for the stride, or None if the variable is not a
+# dynamic-width record (in which case the translation-time width is correct).
+#
+def dynamicRowStride(attributes):
+    if attributes != None and "BASED" in attributes and \
+            "RECORD" in attributes and "DYNAMIC" in attributes:
+        return "COREHALFWORD(%s + 4)" % \
+               memoryMap[attributes["address"]]["superMangled"]
+    return None
+
 # Recursively generate the source code for a C expression that evaluates a tree
 # (previously returned by the `parseExpression` function) created from an XPL 
 # expression.  Returns a pair:
@@ -1305,8 +1330,11 @@ def generateExpression(scope, expression):
         else:
             errxit("Field %s.%s not subscripted properly" % \
                    (baseName, fieldName))
+        rowStride = dynamicRowStride(baseAttributes)
+        if rowStride == None:
+            rowStride = "%d" % baseAttributes["recordSize"]
         sourceAddress = "getFIXED(%s)" % memoryMap[baseAttributes['address']]["superMangled"] + \
-                        " + %d * (%s)" % (baseAttributes["recordSize"],
+                        " + %s * (%s)" % (rowStride,
                                           sourceb) + \
                         " + %d + " % fieldAttributes["offset"] + \
                         "%d * (%s)" % (fieldAttributes["dirWidth"], sourcef)
@@ -1396,6 +1424,9 @@ def generateExpression(scope, expression):
                             entryWidth = 2
                         else:
                             entryWidth = 4
+                    entryWidthSrc = dynamicRowStride(attributes)
+                    if entryWidthSrc == None:
+                        entryWidthSrc = "%d" % entryWidth
                     function = None
                     if "FIXED" in attributes:
                         tipe = "FIXED"
@@ -1413,7 +1444,7 @@ def generateExpression(scope, expression):
                         source = function + baseAddress + ")"
                     else:
                         source = function + baseAddress + \
-                                 " + %d*" % entryWidth + \
+                                 " + %s*" % entryWidthSrc + \
                                  index + ")"
                     return tipe, source
             else:
@@ -1902,9 +1933,12 @@ def generateSingleLine(scope, indent2, line, indexInScope, ps = None):
                 else:
                     errxit("Field %s.%s not subscripted properly" % \
                            (baseName, fieldName))
+                rowStride = dynamicRowStride(baseAttributes)
+                if rowStride == None:
+                    rowStride = "%d" % baseAttributes["recordSize"]
                 try:
                     sourceAddress = "getFIXED(%s)" % memoryMap[baseAttributes['address']]["superMangled"] + \
-                                    " + %d * (%s)" % (baseAttributes["recordSize"],
+                                    " + %s * (%s)" % (rowStride,
                                                       sourceb) + \
                                     " + %d + " % fieldAttributes["offset"] + \
                                     "%d * (%s)" % (fieldAttributes["dirWidth"], sourcef)
@@ -1969,6 +2003,9 @@ def generateSingleLine(scope, indent2, line, indexInScope, ps = None):
                         entryWidth = 2
                     else:
                         entryWidth = 4
+                entryWidthSrc = dynamicRowStride(attributes)
+                if entryWidthSrc == None:
+                    entryWidthSrc = "%d" % entryWidth
                 if len(children) == 1: # Compute index.
                     tipeL, sourceL = generateExpression(scope, children[0])
                     if tipeL != "FIXED":
@@ -1979,7 +2016,7 @@ def generateSingleLine(scope, indent2, line, indexInScope, ps = None):
                         print(indent + "putFIXED(" + baseAddress + ", numberRHS);") 
                     elif len(children) == 1:
                         print(indent + "putFIXED(" + baseAddress + \
-                              "+ %d*(" % entryWidth + \
+                              "+ %s*(" % entryWidthSrc + \
                               sourceL + "), numberRHS);") 
                     else:
                         errxit("Too many subscripts")
@@ -1991,7 +2028,7 @@ def generateSingleLine(scope, indent2, line, indexInScope, ps = None):
                     elif len(children) == 1:
                         print(indent + "putBIT(%d, " % attributes["BIT"] + \
                               baseAddress + \
-                              "+ %d*(" % entryWidth + \
+                              "+ %s*(" % entryWidthSrc + \
                               sourceL + "), bitRHS);") 
                     else:
                         errxit("Too many subscripts")
@@ -2001,7 +2038,7 @@ def generateSingleLine(scope, indent2, line, indexInScope, ps = None):
                         print(indent + "putCHARACTER(" + baseAddress + ", stringRHS);") 
                     elif len(children) == 1:
                         print(indent + "putCHARACTER(" + baseAddress + \
-                              "+ %d*(" % entryWidth + \
+                              "+ %s*(" % entryWidthSrc + \
                               sourceL + "), stringRHS);") 
                     else:
                         errxit("Too many subscripts")

--- a/XCOM-I/runtimeC.c
+++ b/XCOM-I/runtimeC.c
@@ -68,6 +68,8 @@
  *                              adjustable via --tabs=N.
  *              2026-07-09 RSB  Change `sdfFilename` to `sdfDirnameIn` and
  *                              `sdfDirnameOut`.
+ *              2026-08-03 DAS  use runtime record widths set by SET_RECORD_WIDTH
+ *                              on RECORD DYNAMIC tables
  *
  * The functions herein are documented in runtimeC.h.
  *
@@ -3384,7 +3386,7 @@ rawADDR(char *bVar, int32_t bIndex, char *fVar, int32_t fIndex) {
           return foundRawADDR->address;
       }
       address = getFIXED(foundRawADDR->address);       // -> beginning of alloc.
-      address += bIndex * foundRawADDR->recordSize;    // -> beginning of record.
+      address += bIndex * COREHALFWORD(foundRawADDR->address + 4); // -> beginning of record.
       if (fVar == NULL || *fVar == 0 || !strcmp(fVar, "(blank)")) // No field specified.
         return address;
       // Look for the specific field in the record (and the specific

--- a/yaShuttle/Source Code/PASS.REL32V0/PASS2.PROCS/patch42.c
+++ b/yaShuttle/Source Code/PASS.REL32V0/PASS2.PROCS/patch42.c
@@ -14,6 +14,7 @@
    *                            Inspected.
    *            2026-05-01 DS   Alterations related to HFP-native arithmetic.
    *            2026-05-12 RSB  Corrected page number for `L` instruction.
+   *            2026-08-04 DAS  INTEGER_VALUED's result is in GR[3]; return it.
    */
 
 p42_0: ;
@@ -93,4 +94,10 @@ p42_22: ;
   detailedInlineAfter();
 
 p42_24: ;
+  // INTEGER_VALUED returns GR[3]: 1 if the value is an exact integer (the
+  // BC 8 above skipped the SR that zeroes GR[3]), else 0.  Without this the
+  // generator's default `return 0` epilogue makes INTEGER_VALUED always
+  // FALSE, so INTEGER_VALUE returns NEGMAX and POWER_OF_TWO fails for every
+  // scalar literal -- no x1/x2/x4 strength reduction survives.
+  RETURN(GR[3]);
 }


### PR DESCRIPTION
This PR rolls up fixes for four HAL/S-FC optimization/code-gen failure cases I hit while running CON80 builds along with using SDFPKG template loading (which gets much further than textual inclusion!):

- XCOM-I: honor SET_RECORD_WIDTH when indexing BASED RECORD DYNAMIC variables.
- XCOM-I: ADDR(DESCRIPTOR) is freeBase, not the end of XPL-COMMON
- HAL/S-FC PASS2: patch42 must return GR[3], INTEGER_VALUED's result
- XCOM-I: fix INITIAL parser misrouting inner parens into array-dimension parsing

Details are in the commit messages.  "XCOM-I: ADDR(DESCRIPTOR) is freeBase" is a failure case where some source modules will simply fail to compile, the others all produce valid code but miss an optimization.  With these fixes in place the output object are closer to the know "correct" output.

