### PR TITLE
XCOM-I: fix for EXPON & make writing the COMMON image optional

### DIFF
--- a/XCOM-I/runtimeC.c
+++ b/XCOM-I/runtimeC.c
@@ -2867,13 +2867,72 @@ MONITOR9(uint32_t op) {
     r = ibm_dp_div(op0, op1);
   }
   else if (op == 5) {
-    /* a**b — fall back to libm. Convert IBM->IEEE, pow, IEEE->IBM. */
-    double a = ibm_dp_to_double(op0 >> 32, (uint32_t)op0);
-    double b = ibm_dp_to_double(op1 >> 32, (uint32_t)op1);
-    if (a == 0 && b == 0)
-      abend("Zero to the power zero");
-    ibm_dp_from_double(&msw, &lsw, pow(a, b));
-    r = ((uint64_t)msw << 32) | lsw;
+    /* a**b — port of the original MONITOR.bal EXPON routine (cards
+     * 00289400-00293000).  When the exponent b is an exact integer n with
+     * |n| < 2**24 (EXPON's AW-unnormalize test plus its OC 9(4,4) size
+     * check), the original does LSB-first binary square-and-multiply in
+     * S/360 truncating hex FP; for a NEGATIVE exponent it patches the MDR
+     * into DDR, i.e. the accumulator (init 1.0) is DIVIDED by the running
+     * power at each set bit — never positive-power-then-reciprocal.  The
+     * truncation points matter: e.g. 10**(-6) must come out as
+     * X'3C10C6F7A0B5ED8C' (= (1.0 DDR 100) DDR 10000), where the libm
+     * round-trip lands an ULP away.  Non-integer or oversized exponents fall back to libm pow() as
+     * before (the original went through its hex LOG/EXP routines there).
+     */
+    uint64_t b_mant = IBM_DP_MANT(op1);
+    int b_exp = IBM_DP_EXP(op1);
+    int b_neg = IBM_DP_SIGN(op1) != 0;
+    int is_int = 0;
+    uint32_t n = 0;
+    if (b_mant == 0) {          /* b == +/-0 → n = 0 */
+      is_int = 1;
+      n = 0;
+      b_neg = 0;
+    } else {
+      /* Number of hex digits of the mantissa below the binary point. */
+      int k = IBM_DP_EXP_BIAS + IBM_DP_MANT_HEXDIGITS - b_exp;
+      if (k <= 0) {
+        ;  /* |b| >= 16**14: far beyond EXPON's 24-bit limit — fallback */
+      } else if (k < IBM_DP_MANT_HEXDIGITS &&
+                 (b_mant & ((1ULL << (4 * k)) - 1)) == 0) {
+        uint64_t mag = b_mant >> (4 * k);
+        if (mag < (1ULL << 24)) {
+          is_int = 1;
+          n = (uint32_t)mag;
+        }
+      }
+      /* k >= 14 with a nonzero mantissa: |b| < 1 and non-integer. */
+    }
+    if (is_int) {
+      /* EXPON returns RC=1 (error) for 0 ** nonpositive-integer. */
+      if ((op0 & IBM_DP_MANT_MASK) == 0 && (b_neg || n == 0))
+        return 1;
+      uint64_t acc = 0x4110000000000000ULL;  /* D#ONE */
+      uint64_t base = op0;
+      while (n != 0) {
+        int bit = n & 1;
+        n >>= 1;
+        if (bit) {
+          if (b_neg) {
+            if ((base & IBM_DP_MANT_MASK) == 0)
+              return 1;  /* running power underflowed to 0: divide fault */
+            acc = ibm_dp_div(acc, base);
+          } else
+            acc = ibm_dp_mul(acc, base);
+        }
+        if (n != 0)
+          base = ibm_dp_mul(base, base);  /* MDR 0,0 */
+      }
+      r = acc;
+    } else {
+      /* Fall back to libm. Convert IBM->IEEE, pow, IEEE->IBM. */
+      double a = ibm_dp_to_double(op0 >> 32, (uint32_t)op0);
+      double b = ibm_dp_to_double(op1 >> 32, (uint32_t)op1);
+      if (a == 0 && b == 0)
+        abend("Zero to the power zero");
+      ibm_dp_from_double(&msw, &lsw, pow(a, b));
+      r = ((uint64_t)msw << 32) | lsw;
+    }
   }
   else if (op >= 6 && op <= 11) {
     /* Unary transcendentals — same IEEE round-trip as before. */

--- a/XCOM-I/runtimeC.c
+++ b/XCOM-I/runtimeC.c
@@ -886,6 +886,8 @@ parseParmField(int print) {
     putCHARACTER(address + 4 * i, &type1Actual[i]);
 }
 
+static int writeCommonImage = 1;
+
 static void
 openCommonOutFile(char *filename)
 {
@@ -901,6 +903,8 @@ openCommonOutFile(char *filename)
       COMMON_OUT = fopen(filename, "w");
       if (COMMON_OUT == NULL)
 	    abend("Unable to open COMMON output file");
+      if (!writeCommonImage)
+        return;
       sprintf(s, "%s.bin.gz", filename);
       COMMON_OUTz = gzopen(s, "wb");
       if (COMMON_OUTz == NULL)
@@ -941,6 +945,11 @@ parseCommandLine(int argc, char **argv)
   DCB_INS[0].fp = DCB_INS[1].fp = stdin;
   DCB_OUTS[0].fp = DCB_OUTS[1].fp = stdout;
 
+  // Before the main loop, so it cannot depend on switch order.
+  for (i = 1; i < argc; i++)
+    if (!strcmp("--no-common-image", argv[i]))
+      writeCommonImage = 0;
+
   for (i = 1; i < argc; i++)
     {
       int n, lun, recordSize;
@@ -948,6 +957,8 @@ parseCommandLine(int argc, char **argv)
       n = 0;
       if (!strcmp("--utf8", argv[i]))
         outUTF8 = 1;
+      else if (!strcmp("--no-common-image", argv[i]))
+        ;                       // already handled, above
 #ifdef RSB_TRACE
       else if (1 == sscanf(argv[i], "--rsb-trace=%d", &j))
 	productionTrigger = j;
@@ -1214,6 +1225,8 @@ parseCommandLine(int argc, char **argv)
           printf("              default, the file COMMON.out is used.\n");
           printf("              Note that COMMON is a feature of XPL/I, and\n");
           printf("              hence is disabled for standard XPL programs.\n");
+          printf("--no-common-image\n");
+          printf("              Disable writing the COMMON memory image.\n");
           printf("--parm=S      Specifies a PARM FIELD such as would originally\n");
           printf("              have been provided in JCL.\n");
           printf("--sdfi=D      Name of a directory used for reading Simulation Data\n");


### PR DESCRIPTION
Fixes for XCOM-I and the HAL/S-FC compiler:

- use the original MONITOR.bal EXPON algorithm in MONITOR(9) op 5
  - it has a special case path for integer exponents that produces slightly different results than libm pow()
  - still falls back to libm for the non-integer case
  - resolves literal diffs in SSMANTMG & GTBUPL

- add --no-common-image option that skips the output and gzip'ing of the COMMON output file
  - no one seems to consume it by default, and the operation is expensive enough that in some cases it take ~40% of the total runtime of the process.
  - defaults to disabled
  - I enable it in my build system and it results in significant reduction in compile times.  